### PR TITLE
Change __construct access to public.

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -37,7 +37,7 @@ class Caldera_Forms {
 	 * Initialize the plugin by setting localization, filters, and administration functions.
 	 *
 	 */
-	private function __construct() {
+	function __construct() {
 
 		// Load plugin text domain
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );


### PR DESCRIPTION
Allows this method for outputting a form, which doesn't work if access is private
`$caldera = new \Caldera_Forms();`
`$form    = $caldera::render_form( $caldera_id );`
