### PR TITLE
Running file_exists on a URL prefixed with "//" takes forever to run

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -671,7 +671,7 @@ class Caldera_Forms_Admin {
 
 							}else{
 								// is url - 
-								if(file_exists( $style )){
+								if('//' != substr( $script, 0, 2) && file_exists( $style )){
 									// local file
 									wp_enqueue_style( $key, plugin_dir_url( $style ) . basename( $style ), array(), self::VERSION );
 								}else{
@@ -706,7 +706,7 @@ class Caldera_Forms_Admin {
 
 							}else{
 								// is url - 
-								if(file_exists( $script )){
+								if('//' != substr( $script, 0, 2) && file_exists( $script )){
 									// local file
 									wp_enqueue_script( $key, plugin_dir_url( $script ) . basename( $script ), array('jquery'), self::VERSION );
 								}else{


### PR DESCRIPTION
When a filepath is prefixed with "//", Windows attempts to locate a **network share** with that address (which I'm guessing is the bottleneck).

E.g. //www.google.com/recaptcha/api/js/recaptcha_ajax.js

This patch skips the `file_exists` check if the $script starts with "//". There's probably a more elegant fix, such as using is_ssl() to force either "http:" or "https:"
