### PR TITLE
Removed &nbsp; from radio and checkbox type inputs

### DIFF
--- a/fields/checkbox/field.php
+++ b/fields/checkbox/field.php
@@ -28,7 +28,7 @@
 				<?php if(empty($field['config']['inline'])){ ?>
 				<div class="checkbox">
 				<?php } ?>
-				<label<?php if(!empty($field['config']['inline'])){ ?> class="checkbox-inline"<?php } ?> for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><input <?php echo $parsley_req; ?> type="checkbox" data-label="<?php echo esc_attr( $option['label'] );?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" id="<?php echo $field_id . '_' . $option_key; ?>" class="<?php echo $field_id . $req_class; ?>" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $option_key ); ?>]" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( in_array( $option['value'], (array) $field_value) ){ ?>checked="checked"<?php } ?>> <?php echo $option['label']; ?></label>&nbsp;
+				<label<?php if(!empty($field['config']['inline'])){ ?> class="checkbox-inline"<?php } ?> for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><input <?php echo $parsley_req; ?> type="checkbox" data-label="<?php echo esc_attr( $option['label'] );?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" id="<?php echo $field_id . '_' . $option_key; ?>" class="<?php echo $field_id . $req_class; ?>" name="<?php echo esc_attr( $field_name ); ?>[<?php echo esc_attr( $option_key ); ?>]" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( in_array( $option['value'], (array) $field_value) ){ ?>checked="checked"<?php } ?>> <?php echo $option['label']; ?></label>
 				<?php if(empty($field['config']['inline'])){ ?>
 				</div>
 				<?php } ?>

--- a/fields/radio/field.php
+++ b/fields/radio/field.php
@@ -34,7 +34,7 @@
 				<?php if(empty($field['config']['inline'])){ ?>
 				<div class="radio">
 				<?php } ?>
-				<label<?php if(!empty($field['config']['inline'])){ ?> class="radio-inline"<?php } ?> data-label="<?php echo esc_attr( $option['label'] ); ?>" for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><input type="radio" id="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_id . $req_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( $field_value == $option['value'] || $field_value == $option_key ){ ?>checked="checked"<?php } ?> <?php echo $field_required; ?>> <?php echo $option['label']; ?></label>&nbsp;
+				<label<?php if(!empty($field['config']['inline'])){ ?> class="radio-inline"<?php } ?> data-label="<?php echo esc_attr( $option['label'] ); ?>" for="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>"><input type="radio" id="<?php echo esc_attr( $field_id . '_' . $option_key ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_id . $req_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $option['value'] ); ?>" <?php if( $field_value == $option['value'] || $field_value == $option_key ){ ?>checked="checked"<?php } ?> <?php echo $field_required; ?>> <?php echo $option['label']; ?></label>
 				<?php if(empty($field['config']['inline'])){ ?>
 				</div>
 				<?php } ?>


### PR DESCRIPTION
These have no use except for spacing the seperate radio and checkbox
fields. Spacing should be left to the stylesheet.

fixed #1087 

Hopefully this is on the correct branches this time, I'm new to this whole committing thing so thank you for your patience