### PR TITLE
Remove 'html' from forbidden_tags array

### DIFF
--- a/fields/html/field.php
+++ b/fields/html/field.php
@@ -3,7 +3,7 @@ $html_template = '';
 // magics!
 $syncer = Caldera_Forms_Sync_Factory::get_object( $form, $field, Caldera_Forms_Field_Util::get_base_id( $field, null, $form ) );
 $sync = $syncer->can_sync();
-$forbidden_tags = array( 'form', 'iframe', 'script', 'html' );
+$forbidden_tags = array( 'form', 'iframe', 'script' );
 
 if( $sync ){
 	$default = $syncer->get_default();


### PR DESCRIPTION
Remove 'html' from forbidden_tags array. Fixes content not displaying on frontend when using HTML field.