### PR TITLE
Conditional Recipient fix

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1125,6 +1125,12 @@ class Caldera_Forms {
 				"template"    => CFCORE_PATH . "processors/redirect/config.php",
 				"single"      => false
 			),
+			'conditional_recipient'	=> array(
+				"name"        => __( 'Conditional Recipient', 'caldera-forms' ),
+				"description" => __( 'Send email to different recipients depending on conditons', 'caldera-forms' ),
+				"template"    => CFCORE_PATH . "processors/conditional_recipient/config.php",
+				"single"      => false
+			),
 			'increment_capture' => array(
 				"name"         => __( 'Increment Value', 'caldera-forms' ),
 				"description"  => __( 'Increment a value per entry.', 'caldera-forms' ),


### PR DESCRIPTION
Added a call to include the conditional recipient as it wasn't showing up under 'add processor' tab

Fix for - https://github.com/CalderaWP/Caldera-Forms/issues/1254