### PR TITLE
Fix for issue #1327 (textarea value blank on edit)

### DIFF
--- a/fields/paragraph/field.php
+++ b/fields/paragraph/field.php
@@ -10,7 +10,7 @@ if ( is_array( $field_value ) )  {
 
 $syncer = Caldera_Forms_Sync_Factory::get_object( $form, $field, $field_base_id );
 $sync = $syncer->can_sync();
-$field_value = $default = $syncer->get_default();
+$default = $syncer->get_default();
 
 
 $attrs = array(


### PR DESCRIPTION
Fix for issue #1327: Text Area shows blank once editing data (bug)
The value of a text area was always set to its default value, even when editing.