### PR TITLE
Add Magic Tags Support to Paragraph Field Default value

### DIFF
--- a/fields/paragraph/field.php
+++ b/fields/paragraph/field.php
@@ -31,6 +31,10 @@ if(!empty($field['config']['placeholder'])){
 	$attrs[ 'placeholder' ] = Caldera_Forms::do_magic_tags( $field['config']['placeholder'] );
 }
 
+if(!empty($field['config']['default'])){
+	$attrs[ 'default' ] = Caldera_Forms::do_magic_tags( $field['config']['default'] );
+}
+
 
 if( ! empty( $sync ) ){
 	$attrs[ 'data-binds' ] = wp_json_encode($syncer->get_binds() );


### PR DESCRIPTION
Currently only the placeholder supports Magic Tags, the default value could also benefit from it.
The UI allows the selection of the magic tags but the tags are not replaced.

Currently the only way to fix it is to alter the rendering of the paragraph field like this:

add_filter( 'caldera_forms_render_get_field_slug-billing_address',  'render_my_field'  );
function render_my_field( $field ) {
	if ( !empty( $field[ 'config' ][ 'default' ] ) ) {
		$field[ 'config' ][ 'default' ] = Caldera_Forms::do_magic_tags( $field[ 'config' ][ 'default' ] );
	}
	return $field;
}