### PR TITLE
#1610 Fix status column creation error on activation

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -572,6 +572,9 @@ class Caldera_Forms {
 			// add status
 			$columns = $wpdb->get_results( "SHOW COLUMNS FROM `" . $wpdb->prefix . "cf_form_entries`", ARRAY_A );
 			$fields  = array();
+			foreach ( $columns as $column ) {
+				$fields[] = $column[ 'Field' ];
+			}
 
 			if ( ! in_array( 'status', $fields ) && $version < '1.2.0' ) {
 				$wpdb->query( "ALTER TABLE `" . $wpdb->prefix . "cf_form_entries` ADD `status` varchar(20) NOT NULL DEFAULT 'active' AFTER `datestamp`;" );


### PR DESCRIPTION
Fixes issue #1610.  The $fields array was always empty, so activation of the plugin on a new install would always attempt to create the field and the key a 2nd time. 