### PR TITLE
Allow Multiple Recipients & BCCs

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1938,7 +1938,7 @@ class Caldera_Forms {
 	 *
 	 * @param string $value
 	 * @param null|int $entry_id Optional. Entry ID to test by.
-	 * @param array $magic_caller The form/processorr/entry to evaluate against. May also be a powerful wizard.
+	 * @param array $magic_caller The form/processor/entry to evaluate against. May also be a powerful wizard.
 	 *
 	 * @return mixed
 	 */

--- a/classes/save.php
+++ b/classes/save.php
@@ -209,7 +209,13 @@ class Caldera_Forms_Save_Final {
 			$mail['bcc'] = false;
 			if ( isset( $form['mailer']['bcc_to'] ) && ! empty( $form['mailer']['bcc_to'] ) ) {
 				$mail['bcc']       = $form['mailer']['bcc_to'];
-				$mail['headers'][] = Caldera_Forms::do_magic_tags( 'Bcc: ' . $form['mailer']['bcc_to'] );
+
+				$bcc_array = array_map('trim', preg_split( '/[;,]/', Caldera_Forms::do_magic_tags( $form['mailer']['bcc_to'] ) ) );
+				foreach( $bcc_array as $bcc_to ) {
+					if ( is_email( $bcc_to ) ) {
+						$mail['headers'][] = 'Bcc: ' . $bcc_to;
+					}
+				}
 			}
 
 			// if added a replyto
@@ -283,13 +289,15 @@ class Caldera_Forms_Save_Final {
 
 
 			if ( ! empty( $form['mailer']['recipients'] ) ) {
-				$mail['recipients'] = explode( ',', Caldera_Forms::do_magic_tags( $form['mailer']['recipients'] ) );
+				$recipients_array = array_map('trim', preg_split( '/[;,]/', Caldera_Forms::do_magic_tags( $form['mailer']['recipients'] ) ) );
+				foreach( $recipients_array as $recipient ) {
+					if ( is_email( $recipient ) ) {
+						$mail['recipients'][] = $recipient;
+					}
+				}
 			} else {
 				$mail['recipients'][] = get_option( 'admin_email' );
 			}
-
-
-
 
 			$submission = $labels = array();
 			foreach ( $data as $field_id => $row ) {
@@ -356,6 +364,9 @@ class Caldera_Forms_Save_Final {
 			$mail = $settings;
 			$csvfile = $settings[ 'csv' ];
 		}
+
+		var_dump($mail);
+		die();
 
 		if( empty( $mail ) ){
 			/**

--- a/classes/save.php
+++ b/classes/save.php
@@ -365,9 +365,6 @@ class Caldera_Forms_Save_Final {
 			$csvfile = $settings[ 'csv' ];
 		}
 
-		var_dump($mail);
-		die();
-
 		if( empty( $mail ) ){
 			/**
 			 * Runs if mail was not sent because mail variable is empty.


### PR DESCRIPTION
Fixes #1607

Both the recipient and bcc headers are now split by both semicolons and commas to allow for multiple email addresses to be specified in each field.  The recipient header is passed to mail() as an array, the BCC value is split into multiple Bcc: header lines.

I left the ['mailer']['bcc'] value as the original string for backwards compatibility.  As far as I can tell, this isn't required, but I didn't want to break anyone else's implementations. 