### PR TITLE
Added default value text boxes for select options

### DIFF
--- a/fields/checkbox/config_template.php
+++ b/fields/checkbox/config_template.php
@@ -6,3 +6,11 @@
         </label>
 	</div>
 </div>
+<div class="caldera-config-group">
+	<label for="{{_id}}_default">
+		<?php esc_html_e('Default Value'); ?>
+	</label>
+	<div class="caldera-config-field">
+		<input type="text" id="{{_id}}_default" class="block-input field-config magic-tag-enabled" name="{{_name}}[default]" value="{{default}}" placeholder='Matched against values'>
+	</div>
+</div>

--- a/fields/checkbox/field.php
+++ b/fields/checkbox/field.php
@@ -10,6 +10,18 @@
 			$parsley_req = 'data-parsley-required="true" data-parsley-group="' . esc_attr( $field_id ) . '" data-parsley-multiple="' . esc_attr( $field_id ). '"';
 		}
 
+		/////// Note this needs to be updated in order to handle array field_values !!
+		// If the field value set doesn't exist, set it back to null
+		if( !empty($field['config']['option']) ){
+			$option_values = array_map( function($v){ 
+				return isset($v['value']) ? $v['value'] : $v['label']; 
+			}, $field[ 'config' ][ 'option' ] );
+
+			if(!in_array($field_value, $option_values)){
+				$field_value = null;
+			}
+		}
+
 		if(!empty($field['config']['option'])){
 			
 			// If default exists and val doesn't, set it

--- a/fields/checkbox/field.php
+++ b/fields/checkbox/field.php
@@ -12,10 +12,12 @@
 
 		if(!empty($field['config']['option'])){
 			
-			if(isset( $field['config'] ) && isset($field['config']['default']) && isset($field['config']['option'][$field['config']['default']])){
-				
-				if( $field['config']['default'] === $field_value ){
-					$field_value = (array) $field['config']['option'][$field['config']['default']]['value'];
+			// If default exists and val doesn't, set it
+			if( isset( $field['config'] ) && 
+				isset($field['config']['default_option']) && 
+				isset($field['config']['option'][$field['config']['default_option']])){
+				if( $field_value == null ){
+					$field_value = (array) $field['config']['option'][$field['config']['default_option']]['value'];
 				}
 
 			}

--- a/fields/checkbox/preview.php
+++ b/fields/checkbox/preview.php
@@ -6,7 +6,7 @@
 			{{#unless ../config/inline}}
 			<div>
 			{{/unless}}
-			<label style="margin: 0px 10px 0px 0px;"><input type="checkbox" class="preview-field-config" {{#is ../config/default value="@key"}}checked="checked"{{/is}}> {{label}}</label>
+			<label style="margin: 0px 10px 0px 0px;"><input type="checkbox" class="preview-field-config" {{#is ../config/default_option value="@key"}}checked="checked"{{/is}}> {{label}}</label>
 			{{#unless ../config/inline}}
 			</div>
 			{{/unless}}

--- a/fields/dropdown/config_template.php
+++ b/fields/dropdown/config_template.php
@@ -6,3 +6,11 @@
 		<input type="text" id="{{_id}}_placeholder" class="block-input field-config" name="{{_name}}[placeholder]" value="{{placeholder}}">
 	</div>
 </div>
+<div class="caldera-config-group">
+	<label for="{{_id}}_default">
+		<?php esc_html_e('Default Value'); ?>
+	</label>
+	<div class="caldera-config-field">
+		<input type="text" id="{{_id}}_default" class="block-input field-config magic-tag-enabled" name="{{_name}}[default]" value="{{default}}" placeholder='Matched against values'>
+	</div>
+</div>

--- a/fields/dropdown/field.php
+++ b/fields/dropdown/field.php
@@ -19,6 +19,17 @@ $attr_string =  caldera_forms_field_attributes( $attrs, $field, $form );
 		<select <?php echo $attr_string . ' ' . $field_required . ' ' . $field_structure['aria']; ?> >
 		<?php
 
+			// If the field value set doesn't exist, set it back to null
+			if( !empty($field['config']['option']) ){
+				$option_values = array_map( function($v){ 
+					return isset($v['value']) ? $v['value'] : $v['label']; 
+				}, $field[ 'config' ][ 'option' ] );
+
+				if(!in_array($field_value, $option_values)){
+					$field_value = null;
+				}
+			}
+
 			// If default exists and val doesn't, set it
 			if( isset( $field['config'] ) && 
 				isset($field['config']['default_option']) && 

--- a/fields/dropdown/field.php
+++ b/fields/dropdown/field.php
@@ -19,10 +19,12 @@ $attr_string =  caldera_forms_field_attributes( $attrs, $field, $form );
 		<select <?php echo $attr_string . ' ' . $field_required . ' ' . $field_structure['aria']; ?> >
 		<?php
 
-			if(isset( $field['config'] ) && isset($field['config']['default']) && isset($field['config']['option'][$field['config']['default']])){
-
-				if( $field['config']['default'] === $field_value ){
-					$field_value = $field['config']['option'][$field['config']['default']]['value'];
+			// If default exists and val doesn't, set it
+			if( isset( $field['config'] ) && 
+				isset($field['config']['default_option']) && 
+				isset($field['config']['option'][$field['config']['default_option']])){
+				if( $field_value == null ){
+					$field_value = $field['config']['option'][$field['config']['default_option']]['value'];
 				}
 
 			}else{

--- a/fields/dropdown/preview.php
+++ b/fields/dropdown/preview.php
@@ -4,7 +4,7 @@
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>
 		{{#each config/option}}
-			<option {{#is ../config/default value="@key"}}selected="selected"{{/is}}>{{label}}</option>
+			<option {{#is ../config/default_option value="@key"}}selected="selected"{{/is}}>{{label}}</option>
 		{{/each}}
 		</select>
 		<span class="help-block">{{caption}}</span>

--- a/fields/radio/config_template.php
+++ b/fields/radio/config_template.php
@@ -7,3 +7,11 @@
         </label>
 	</div>
 </div>
+<div class="caldera-config-group">
+	<label for="{{_id}}_default">
+		<?php esc_html_e('Default Value'); ?>
+	</label>
+	<div class="caldera-config-field">
+		<input type="text" id="{{_id}}_default" class="block-input field-config magic-tag-enabled" name="{{_name}}[default]" value="{{default}}" placeholder='Matched against values'>
+	</div>
+</div>

--- a/fields/radio/field.php
+++ b/fields/radio/field.php
@@ -8,17 +8,18 @@ if( !empty( $field['required'] ) ){
 	$req_class = ' option-required';
 }
 
-
-if(empty($field['config']['option'])){
-
-	if(isset( $field['config'] ) && isset($field['config']['default']) && isset($field['config']['option'][$field['config']['default']])){
-
-		if( $field['config']['default'] === $field_value ){
-			$field_value = $field['config']['option'][$field['config']['default']]['value'];
-		}
-
+// If default exists and val doesn't, set it
+if( isset( $field['config'] ) && 
+	isset($field['config']['default_option']) && 
+	isset($field['config']['option'][$field['config']['default_option']])){
+	if( $field_value == null ){
+		$field_value = $field['config']['option'][$field['config']['default_option']]['value'];
 	}
 
+}
+
+
+if(empty($field['config']['option'])){
 	?>
 
 	<input type="radio" id="<?php echo esc_attr( $field_id ); ?>" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="field-config<?php echo $req_class; ?>" name="<?php echo esc_attr( $field_name ); ?>" value="1" <?php if(!empty($field_value)){ ?>checked="checked"<?php } ?> data-radio-field="<?php echo esc_attr( $field_id ); ?> data-type="radio" data-calc-value="<?php echo esc_attr( Caldera_Forms_Field_Util::get_option_calculation_value( $option, $field, $form ) ); ?>" />
@@ -27,7 +28,7 @@ if(empty($field['config']['option'])){
 	foreach($field['config']['option'] as $option_key=>$option){
 		$checked = false;
 		$disabled = false;
-		if( $field_value === $option['value'] || $field_value === $option_key ) {
+		if( $field_value === $option['value'] ) {
 			$checked = true;
 		}
 

--- a/fields/radio/field.php
+++ b/fields/radio/field.php
@@ -8,6 +8,18 @@ if( !empty( $field['required'] ) ){
 	$req_class = ' option-required';
 }
 
+
+// If the field value set doesn't exist, set it back to null
+if( !empty($field['config']['option']) ){
+	$option_values = array_map( function($v){ 
+		return isset($v['value']) ? $v['value'] : $v['label']; 
+	}, $field[ 'config' ][ 'option' ] );
+
+	if(!in_array($field_value, $option_values)){
+		$field_value = null;
+	}
+}
+
 // If default exists and val doesn't, set it
 if( isset( $field['config'] ) && 
 	isset($field['config']['default_option']) && 

--- a/fields/radio/preview.php
+++ b/fields/radio/preview.php
@@ -6,7 +6,7 @@
 			{{#unless ../config/inline}}
 			<div>
 			{{/unless}}
-			<label style="margin: 0px 10px 0px 0px;"><input type="radio" class="preview-field-config" {{#is ../config/default value="@key"}}checked="checked"{{/is}}> {{label}}</label>
+			<label style="margin: 0px 10px 0px 0px;"><input type="radio" class="preview-field-config" {{#is ../config/default_option value="@key"}}checked="checked"{{/is}}> {{label}}</label>
 			{{#unless ../config/inline}}
 			</div>
 			{{/unless}}

--- a/fields/select2/field/config.php
+++ b/fields/select2/field/config.php
@@ -33,4 +33,11 @@
 		<input id="{{_id}}_border" type="text" class="color-field field-config" name="{{_name}}[border]" value="{{#if border}}{{border}}{{else}}#4b8dc9{{/if}}">		
 	</div>
 </div>
-
+<div class="caldera-config-group">
+	<label for="{{_id}}_default">
+		<?php esc_html_e('Default Value'); ?>
+	</label>
+	<div class="caldera-config-field">
+		<input type="text" id="{{_id}}_default" class="block-input field-config magic-tag-enabled" name="{{_name}}[default]" value="{{default}}" placeholder='Matched against values'>
+	</div>
+</div>

--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -12,9 +12,18 @@ if( !empty( $field['config']['advanced_populate']['filter'] ) ){
 				}
 			}
 		}
-	}
+	}	
+}
 
-	
+// If the field value set doesn't exist, set it back to null
+if( !empty($field['config']['option']) ){
+	$option_values = array_map( function($v){ 
+		return isset($v['value']) ? $v['value'] : $v['label']; 
+	}, $field[ 'config' ][ 'option' ] );
+
+	if(!in_array($field_value, $option_values)){
+		$field_value = null;
+	}
 }
 
 // default
@@ -60,7 +69,7 @@ if( empty( $field['config']['color'] ) ){
 
 
 		if(!empty($field['config']['option'])){
-			if(!empty($field['config']['default'])){
+			if(!empty($field['config']['default_option'])){
 				if(!isset($field['config']['option'][$field['config']['default_option']])){
 					echo "<option value=\"\"></option>\r\n";
 				}

--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -47,19 +47,21 @@ if( empty( $field['config']['color'] ) ){
 		<?php if( empty( $bound ) ){ ?>
 		<select <?php echo $field_placeholder; ?> id="<?php echo esc_attr( $field_id ); ?>" <?php echo $multi; ?> data-select-two="true" data-field="<?php echo esc_attr( $field_base_id ); ?>" class="<?php echo esc_attr( $field_class ); ?>" name="<?php echo esc_attr( $field_name ); ?>" <?php echo $field_required; ?> <?php echo $placeholder; ?>>
 		<?php
-			if(isset( $field['config'] ) && isset($field['config']['default']) && isset($field['config']['option'][$field['config']['default']])){
-				//if( $field['config']['option'][$field['config']['default']]['value'] )
-				if( $field['config']['default'] === $field_value ){
-					$field_value = $field['config']['option'][$field['config']['default']]['value'];
+			
+			// If default exists and val doesn't, set it
+			if( isset($field['config']) && 
+				isset($field['config']['default_option']) && 
+				isset($field['config']['option'][$field['config']['default_option']])){
+				if( $field_value == null ){
+					$field_value = $field['config']['option'][$field['config']['default_option']]['value'];
 				}
-
 
 			}
 
 
 		if(!empty($field['config']['option'])){
 			if(!empty($field['config']['default'])){
-				if(!isset($field['config']['option'][$field['config']['default']])){
+				if(!isset($field['config']['option'][$field['config']['default_option']])){
 					echo "<option value=\"\"></option>\r\n";
 				}
 			}elseif( !empty( $field['config']['placeholder'] ) ){

--- a/fields/select2/field/preview.php
+++ b/fields/select2/field/preview.php
@@ -4,7 +4,7 @@
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>
 		{{#each config/option}}
-			<option {{#is ../config/default value="@key"}}selected="selected"{{/is}}>{{label}}</option>
+			<option {{#is ../config/default_option value="@key"}}selected="selected"{{/is}}>{{label}}</option>
 		{{/each}}
 		</select>
 		<span class="help-block">{{caption}}</span>

--- a/fields/toggle_switch/config_template.php
+++ b/fields/toggle_switch/config_template.php
@@ -28,3 +28,11 @@
 		<input id="{{_id}}_inactiveclass"type="text" value="{{#if default_class}}{{default_class}}{{else}}btn-default{{/if}}" name="{{_name}}[default_class]" class="block-input field-config">
 	</div>
 </div>
+<div class="caldera-config-group">
+	<label for="{{_id}}_default">
+		<?php esc_html_e('Default Value'); ?>
+	</label>
+	<div class="caldera-config-field">
+		<input type="text" id="{{_id}}_default" class="block-input field-config magic-tag-enabled" name="{{_name}}[default]" value="{{default}}" placeholder='Matched against values'>
+	</div>
+</div>

--- a/fields/toggle_switch/field.php
+++ b/fields/toggle_switch/field.php
@@ -24,11 +24,13 @@ if(!empty($field['config']['orientation']) && $field['config']['orientation'] ==
 		<div class="cf-toggle-group-buttons <?php echo $groupOrientation; ?>">
 			<?php
 
-			if(isset( $field['config'] ) && isset($field['config']['default']) && isset($field['config']['option'][$field['config']['default']])){
-				if( $field['config']['default'] === $field_value ){
-					$field_value = $field['config']['option'][$field['config']['default']]['value'];
+			// If default exists and val doesn't, set it
+			if( isset( $field['config'] ) && 
+				isset($field['config']['default_option']) && 
+				isset($field['config']['option'][$field['config']['default_option']])){
+				if( $field_value == null ){
+					$field_value = $field['config']['option'][$field['config']['default_option']]['value'];
 				}
-
 			}
 
 			if(empty($field['config']['option'])){ ?>

--- a/fields/toggle_switch/field.php
+++ b/fields/toggle_switch/field.php
@@ -24,6 +24,17 @@ if(!empty($field['config']['orientation']) && $field['config']['orientation'] ==
 		<div class="cf-toggle-group-buttons <?php echo $groupOrientation; ?>">
 			<?php
 
+			// If the field value set doesn't exist, set it back to null
+			if( !empty($field['config']['option']) ){
+				$option_values = array_map( function($v){ 
+					return isset($v['value']) ? $v['value'] : $v['label']; 
+				}, $field[ 'config' ][ 'option' ] );
+
+				if(!in_array($field_value, $option_values)){
+					$field_value = null;
+				}
+			}
+
 			// If default exists and val doesn't, set it
 			if( isset( $field['config'] ) && 
 				isset($field['config']['default_option']) && 

--- a/fields/toggle_switch/preview.php
+++ b/fields/toggle_switch/preview.php
@@ -3,7 +3,7 @@
 	<div class="preview-caldera-config-field">
 		<div class="toggle_option_preview{{#is config/orientation value="vertical"}} toggle_vertical{{/is}}">
 		{{#each config/option}}
-		<button class="button {{#is ../config/default value="@key"}}button-primary{{/is}}" type="button">{{label}}</button>
+		<button class="button {{#is ../config/default_option value="@key"}}button-primary{{/is}}" type="button">{{label}}</button>
 		{{/each}}
 		</div>
 		<span class="help-block">{{caption}}</span>

--- a/ui/edit.php
+++ b/ui/edit.php
@@ -303,7 +303,7 @@ $field_options_template = "
 		</div>
 	</div>
 	<div class=\"caldera-config-group caldera-config-group-full\">
-	<label style=\"padding: 10px;\"><input type=\"radio\" class=\"toggle_set_default field-config\" name=\"{{_name}}[default]\" value=\"\" {{#unless default}}checked=\"checked\"{{/unless}}> " . esc_html__( 'No Default', 'caldera-forms' ) . "</label>
+	<label style=\"padding: 10px;\"><input type=\"radio\" class=\"toggle_set_default field-config\" name=\"{{_name}}[default_option]\" value=\"\" {{#unless default_option}}checked=\"checked\"{{/unless}}> " . esc_html__( 'No Default', 'caldera-forms' ) . "</label>
 	<label class=\"pull-right\" style=\"padding: 10px;\"><input type=\"checkbox\" class=\"toggle_show_values field-config\" name=\"{{_name}}[show_values]\" value=\"1\" {{#if show_values}}checked=\"checked\"{{/if}}> " . esc_html__( 'Show Values', 'caldera-forms' ) . "</label>
 	</div>
 	
@@ -312,7 +312,7 @@ $field_options_template = "
 			<div class=\"toggle_option_row 315\">
 					<i class=\"dashicons dashicons-sort option-group-control\" style=\"padding: 4px 9px;\"></i>
 					
-					<input type=\"radio\" class=\"toggle_set_default field-config option-group-control\" name=\"{{../_name}}[default]\" value=\"{{@key}}\" {{#is ../default value=\"@key\"}}checked=\"checked\"{{/is}}>
+					<input type=\"radio\" class=\"toggle_set_default field-config option-group-control\" name=\"{{../_name}}[default_option]\" value=\"{{@key}}\" {{#is ../default_option value=\"@key\"}}checked=\"checked\"{{/is}}>
 					
 					<a href=\"https://calderaforms.com/doc/select-options/?utm_source=wp-admin&utm_medium=form-editor&utm_content=discount\" target=\"_blank\" class=\"dashicons dashicons-editor-help\" style=\"float:right;\" data-toggle=\"tooltip\" data-placement=\"bottom\"  title=\"" . esc_attr( __( 'Learn more about using select field options', 'caldera-forms' ) ) . "\"></a>
 		
@@ -992,7 +992,7 @@ do_action('caldera_forms_edit_end', $element);
 	{{#each option}}
 	<div class="toggle_option_row 962">
 		<i class="dashicons dashicons-sort" style="padding: 4px 9px;"></i>
-		<input type="radio" class="toggle_set_default field-config" name="{{../_name}}[default]" value="{{@key}}" {{#is ../default value="@key"}}checked="checked"{{/is}}>
+		<input type="radio" class="toggle_set_default field-config" name="{{../_name}}[default_option]" value="{{@key}}" {{#is ../default_option value="@key"}}checked="checked"{{/is}}>
 		<span style="position: relative; display: inline-block;">
 			<input type="text" class="toggle_calc_value_field field-config magic-tag-enabled" name="{{../_name}}[option][{{@key}}][calc_value]" value="{{calc_value}}" placeholder="calc_value">
 			<input type="text" class="toggle_value_field field-config magic-tag-enabled" name="{{../_name}}[option][{{@key}}][value]" value="{{value}}" placeholder="value">


### PR DESCRIPTION
The fields affected are:
- dropdown
- checkbox
- radio
- select2
- toggle switch

Also, I renamed the "default" field slug in the Add Options section to "default_option" because it is more consistent with the usage of the default field elsewhere and it made implementing the default text field much easier. 

Just a note: checkboxes and select2 fields can't take multiple default values. Perhaps the easiest thing to do would use new line delineated textareas. Before that gets done, multiselect fields still use radio buttons to select the default value meaning that only one default can be chosen. These should be changed to checkboxes.
