### PR TITLE
Add clear button to select2

### DIFF
--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -125,6 +125,8 @@ jQuery( function($){
 	<?php }else{ ?>	
 	var opts = {};
 	<?php } ?>
+	// Only works if placeholder is set
+	opts['allowClear'] = true;
 
 	$(document).on('cf.add', function(){
 		$('#<?php echo $field_id; ?>').select2( opts );


### PR DESCRIPTION
Currently, select2 fields cannot be unset if an option is set. This will add an x to the dropdown which clears the selection back to the placeholder.