### PR TITLE
QCOSS-113: Check if the processed magic value is same as the default value

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -757,7 +757,7 @@ class Caldera_Forms {
 				'entry_id' => $entry_id,
 				'field_id' => $field[ 'ID' ],
 				'slug'     => $field[ 'slug' ],
-				'value'    => self::do_clean_magic_tags( $entry )
+				'value'    => self::do_magic_tags( $entry )
 			);
 
 			// named key kets .key to slug
@@ -786,23 +786,6 @@ class Caldera_Forms {
 		}
 
 	}
-
-	/**
-	 * QCOSS-113: Clean magic tags value
-	 * Check if the processed magic value is same as the default value.
-	 * If yes Make it blank. Required when processor is linked to magic tags and due to some conditions
-	 * they do not have actual value.
-	 */
-	 public static function do_clean_magic_tags($value) {
-		 $magicvalue = self::do_magic_tags( $value );
-		 $magics = Caldera_Forms_Magic_Util::explode_bracket_magic( $value );
-		 if ( ! empty( $magics[ 1 ] ) && $value == $magicvalue) {
-			 $value = "";
-		 } else {
-			 $value = $magicvalue;
-		 }
-		 return $value;
-	 }
 
 	/**
 	 * Save final form data

--- a/classes/core.php
+++ b/classes/core.php
@@ -757,7 +757,7 @@ class Caldera_Forms {
 				'entry_id' => $entry_id,
 				'field_id' => $field[ 'ID' ],
 				'slug'     => $field[ 'slug' ],
-				'value'    => self::do_magic_tags( $entry )
+				'value'    => self::do_clean_magic_tags( $entry )
 			);
 
 			// named key kets .key to slug
@@ -786,6 +786,23 @@ class Caldera_Forms {
 		}
 
 	}
+
+	/**
+	 * QCOSS-113: Clean magic tags value
+	 * Check if the processed magic value is same as the default value.
+	 * If yes Make it blank. Required when processor is linked to magic tags and due to some conditions
+	 * they do not have actual value.
+	 */
+	 public static function do_clean_magic_tags($value) {
+		 $magicvalue = self::do_magic_tags( $value );
+		 $magics = Caldera_Forms_Magic_Util::explode_bracket_magic( $value );
+		 if ( ! empty( $magics[ 1 ] ) && $value == $magicvalue) {
+			 $value = "";
+		 } else {
+			 $value = $magicvalue;
+		 }
+		 return $value;
+	 }
 
 	/**
 	 * Save final form data

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -126,6 +126,11 @@ class Caldera_Forms_Magic_Doer {
 					}
 				}
 
+                $magics = Caldera_Forms_Magic_Util::explode_bracket_magic( $entry );
+                if ( ! empty( $magics[ 1 ])) {
+                    $entry = "";
+                }
+
 				$value = str_replace( $matches[ 0 ][ $key ], $entry, $value );
 			}
 

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -167,7 +167,8 @@ class Caldera_Forms_Magic_Doer {
 		global $processed_meta;
 
 		/**
-		 * 
+		 *
+		 *
 		 */
 		$form   = self::filter_form( $form, $entry_id );
 		$magics = Caldera_Forms_Magic_Util::explode_bracket_magic( $value );
@@ -190,8 +191,7 @@ class Caldera_Forms_Magic_Doer {
 			if( ! is_null( $_value ) ){
 				return $_value;
 			}
-
-			$defaultvalue = $value;
+			
 			foreach ( $magics[ 1 ] as $magic_key => $magic_tag ) {
 
 				$magic = explode( ':', $magic_tag, 2 );
@@ -436,15 +436,6 @@ class Caldera_Forms_Magic_Doer {
 			}
 
 			/**
-			 * QCOSS-113: Check if the processed magic value is same as the default value.
-			 * If yes Make it blank. Required when processor is linked to magic tags and due to some conditions
-			 * they do not have actual value.
-			 */
-			if($defaultvalue == $value) {
-				$value = "";
-			}
-
-			/**
 			 * Change value of parse bracket magic tag
 			 *
 			 * @since 1.5.0
@@ -502,7 +493,7 @@ class Caldera_Forms_Magic_Doer {
 	 * @return array
 	 */
 	public static function magic_tag_meta_prepare( $entry_id ){
-		global $processed_meta;		
+		global $processed_meta;
 		if( ! is_array( self::$entry_details ) )  {
 			self::$entry_details = array();
 		}

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -191,6 +191,7 @@ class Caldera_Forms_Magic_Doer {
 				return $_value;
 			}
 
+			$defaultvalue = $value;
 			foreach ( $magics[ 1 ] as $magic_key => $magic_tag ) {
 
 				$magic = explode( ':', $magic_tag, 2 );
@@ -432,6 +433,15 @@ class Caldera_Forms_Magic_Doer {
 					$value = str_replace( $magics[ 0 ][ $magic_key ], $filter_value, $value );
 				}
 
+			}
+
+			/**
+			 * QCOSS-113: Check if the processed magic value is same as the default value.
+			 * If yes Make it blank. Required when processor is linked to magic tags and due to some conditions
+			 * they do not have actual value.
+			 */
+			if($defaultvalue == $value) {
+				$value = "";
 			}
 
 			/**


### PR DESCRIPTION
## Before
If the form has two processors (A & B), one of the processor has magic tags (A) and second processor(B) is using those magic tags to store the values. If some conditions matched Processor A is disabled and only Processor B is working. In this case Processor B is saving the magic tag values as {processor_a:field_name} This should not happen, if value is not present we should save blank values.

## After
Now we will save blank values for invalid magic tag values.

## Solution
We're checking the default value with returned value by bracket magic. If both are same we consider it is an invalid value and make it blank.
  
