### PR TITLE
Fix checkbox fields results in viewer Fix #2078

### DIFF
--- a/includes/field_processors.php
+++ b/includes/field_processors.php
@@ -7,6 +7,8 @@ function cf_handle_multi_view( $data, $field ){
 	if( empty( $data ) || !is_array( $data ) ){
 		return $data;
 	}
+	// Remove the json total of checked options
+	array_pop($data);
 	// can put in the value as well.
 	$viewer = array();
 


### PR DESCRIPTION
Remove the json array from checkbox results in the viewer
Actually removed the last item of the array that contained all the previous items.