### PR TITLE
Fix json_decode expects parameter 1 to be a string admin.php L963

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -960,11 +960,11 @@ class Caldera_Forms_Admin {
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
 							// maybe json?
-                                if ( is_string($row->value) ) {
-                                    $is_json = json_decode( $row->value, ARRAY_A );
-                                } else if ( is_array($row->value) ) { //Process all checkbox values
-                                    $is_json = $row->value;
-                                }
+                                            if ( is_string($row->value) ) {
+                                                $is_json = json_decode( $row->value, ARRAY_A );
+                                            } else if ( is_array($row->value) ) { //Process all checkbox values
+                                                $is_json = $row->value;
+                                            }
 
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -960,7 +960,12 @@ class Caldera_Forms_Admin {
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
 							// maybe json?
-							$is_json = json_decode( $row->value, ARRAY_A );
+                            if ( is_string($row->value) ) {
+                                $is_json = json_decode( $row->value, ARRAY_A );
+                            } else if ( is_array($row->value) ) { //Process all checkbox values
+                                $is_json = $row->value;
+                            }
+
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;
 							}else  {

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -959,12 +959,12 @@ class Caldera_Forms_Admin {
 							// check view handler
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
-							// maybe json?
-                                            if ( is_string($row->value) ) {
-                                                $is_json = json_decode( $row->value, ARRAY_A );
-                                            } else if ( is_array($row->value) ) { //Process all checkbox values
-                                                $is_json = $row->value;
-                                            }
+                            // maybe json?
+                            if ( is_string($row->value) ) {
+                                $is_json = json_decode( $row->value, ARRAY_A );
+                            } else if ( is_array($row->value) ) { //Process all checkbox values
+                                $is_json = $row->value;
+                            }
 
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -959,12 +959,12 @@ class Caldera_Forms_Admin {
 							// check view handler
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
-                                            // maybe json?
-                                            if ( is_string($row->value) ) {
-                                                $is_json = json_decode( $row->value, ARRAY_A );
-                                            } else if ( is_array($row->value) ) { //Process all checkbox values
-                                                $is_json = $row->value;
-                                            }
+                                                        // maybe json?
+                                                        if ( is_string($row->value) ) {
+                                                            $is_json = json_decode( $row->value, ARRAY_A );
+                                                        } else if ( is_array($row->value) ) { //Process all checkbox values
+                                                            $is_json = $row->value;
+                                                        }
 
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -960,11 +960,11 @@ class Caldera_Forms_Admin {
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
 							// maybe json?
-                            if ( is_string($row->value) ) {
-                                $is_json = json_decode( $row->value, ARRAY_A );
-                            } else if ( is_array($row->value) ) { //Process all checkbox values
-                                $is_json = $row->value;
-                            }
+                                if ( is_string($row->value) ) {
+                                    $is_json = json_decode( $row->value, ARRAY_A );
+                                } else if ( is_array($row->value) ) { //Process all checkbox values
+                                    $is_json = $row->value;
+                                }
 
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -959,12 +959,12 @@ class Caldera_Forms_Admin {
 							// check view handler
 							$field = Caldera_Forms_Field_Util::get_field(  $row->slug, $form, true );
 
-                            // maybe json?
-                            if ( is_string($row->value) ) {
-                                $is_json = json_decode( $row->value, ARRAY_A );
-                            } else if ( is_array($row->value) ) { //Process all checkbox values
-                                $is_json = $row->value;
-                            }
+                                            // maybe json?
+                                            if ( is_string($row->value) ) {
+                                                $is_json = json_decode( $row->value, ARRAY_A );
+                                            } else if ( is_array($row->value) ) { //Process all checkbox values
+                                                $is_json = $row->value;
+                                            }
 
 							if ( ! empty( $is_json ) ) {
 								$row->value = $is_json;


### PR DESCRIPTION
Closes #1996 Caldera_Forms_Admin::get_entries returned a notice for json_decode that actually caused issues.