### PR TITLE
Form Export: Mark forms exported to PHP as external.

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1321,6 +1321,7 @@ class Caldera_Forms_Admin {
 			}else{
 
 				$form_id = sanitize_key( $_GET['form_id'] );
+				$form['_external_form'] = 1;
 				if( !empty( $_GET['pin_menu'] ) ){
 					$form['pinned'] = 1;
 				}


### PR DESCRIPTION
When a form transitions from being saved into the database to being defined in PHP code, it becomes external. Setting the flag prevents it from being edited by the user in the wp-admin, etc.

Fixes #2245 