### PR TITLE
Check if $entry_id is an array or object in magic_tag_meta_prepare( $entry_id ) and return if true

### DIFF
--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -497,7 +497,7 @@ class Caldera_Forms_Magic_Doer {
 			self::$entry_details = array();
 		}
 
-                if( ! is_numeric( $entry_id ) ) {
+                if( is_array( $entry_id ) || is_object( $entry_id ) ) {
                     return;
                 }
 

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -497,9 +497,9 @@ class Caldera_Forms_Magic_Doer {
 			self::$entry_details = array();
 		}
 
-        if( ! is_numeric( $entry_id ) ) {
-            return;
-        }
+            if( ! is_numeric( $entry_id ) ) {
+                return;
+            }
 
 		if( ! isset( self::$entry_details[ $entry_id ] ) ) {
 			$entry_details = Caldera_Forms::get_entry_detail( $entry_id );

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -497,6 +497,9 @@ class Caldera_Forms_Magic_Doer {
 			self::$entry_details = array();
 		}
 
+        if( ! is_numeric( $entry_id ) ) {
+            return;
+        }
 
 		if( ! isset( self::$entry_details[ $entry_id ] ) ) {
 			$entry_details = Caldera_Forms::get_entry_detail( $entry_id );

--- a/classes/magic/doer.php
+++ b/classes/magic/doer.php
@@ -497,9 +497,9 @@ class Caldera_Forms_Magic_Doer {
 			self::$entry_details = array();
 		}
 
-            if( ! is_numeric( $entry_id ) ) {
-                return;
-            }
+                if( ! is_numeric( $entry_id ) ) {
+                    return;
+                }
 
 		if( ! isset( self::$entry_details[ $entry_id ] ) ) {
 			$entry_details = Caldera_Forms::get_entry_detail( $entry_id );


### PR DESCRIPTION
Prevent wrong value as the key of an array when custom fields processor is used

#2318 When custom fields processor is used, an array is used as the key of an array. 
$entry_id is an array in magic_tag_meta_prepare( $entry_id ) when custom fields is used.