### PR TITLE
Better mp3 handling in advanced file fields

### DIFF
--- a/caldera-core.php
+++ b/caldera-core.php
@@ -4,11 +4,7 @@
   Plugin URI: https://CalderaForms.com
   Description: Easy to use, grid based responsive form builder for creating simple to complex forms.
   Author: Caldera Labs
-<<<<<<< HEAD
   Version: 1.6.2.b.1
-=======
-  Version: 1.6.1.1
->>>>>>> master
   Author URI: http://CalderaLabs.org
   Text Domain: caldera-forms
   GitHub Plugin URI: https://github.com/CalderaWP/caldera-forms
@@ -22,11 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 define('CFCORE_PATH', plugin_dir_path(__FILE__));
 define('CFCORE_URL', plugin_dir_url(__FILE__));
-<<<<<<< HEAD
 define( 'CFCORE_VER', '1.6.2.b.1' );
-=======
-define( 'CFCORE_VER', '1.6.1.1' );
->>>>>>> master
 define('CFCORE_EXTEND_URL', 'https://api.calderaforms.com/1.0/');
 define('CFCORE_BASENAME', plugin_basename( __FILE__ ));
 
@@ -82,14 +74,14 @@ function caldera_forms_load(){
 	include_once CFCORE_PATH . 'processors/functions.php';
 	include_once CFCORE_PATH . 'includes/functions.php';
 	include_once CFCORE_PATH . 'ui/blocks/init.php';
-    include_once CFCORE_PATH . 'includes/cf-pro-client/cf-pro-init.php';
-    /**
+	include_once CFCORE_PATH . 'includes/cf-pro-client/cf-pro-init.php';
+	/**
 	 * Runs after all of the includes and autoload setup is done in Caldera Forms core
 	 *
 	 * @since 1.3.5.3
 	 */
 	do_action( 'caldera_forms_includes_complete' );
-    caldera_forms_freemius()->add_filter('plugin_icon', 'caldera_forms_freemius_icon_path' );
+	caldera_forms_freemius()->add_filter('plugin_icon', 'caldera_forms_freemius_icon_path' );
 }
 
 add_action( 'plugins_loaded', array( 'Caldera_Forms', 'get_instance' ) );
@@ -112,35 +104,35 @@ if ( is_admin() || defined( 'DOING_AJAX' ) ) {
  * @return Freemius
  */
 function caldera_forms_freemius() {
-    global $caldera_forms_freemius;
-    if ( ! isset( $caldera_forms_freemius ) ) {
-        // Include Freemius SDK.
-        require_once CFCORE_PATH . 'includes/freemius/start.php';
-        $caldera_forms_freemius = fs_dynamic_init( array(
-            'id'                  => '1767',
-            'slug'                => 'caldera-forms',
-            'type'                => 'plugin',
-            'public_key'          => 'pk_d8e6325777a98c1b3e0d8cdbfad1e',
-            'is_premium'          => false,
-            'has_addons'          => false,
-            'has_paid_plans'      => false,
-            'menu'                => array(
-                'slug'           => 'caldera-forms',
-                'account'        => false,
-                'support'        => false,
-                'contact'        => false,
-            ),
-        ) );
-        /**
-         * Runs after Freemius loads
-         *
-         * @since 1.6.0
-         *
-         * @param Freemius $caldera_forms_freemius
-         */
-        do_action( 'caldera_forms_freemius_init', $caldera_forms_freemius );
-    }
-    return $caldera_forms_freemius;
+	global $caldera_forms_freemius;
+	if ( ! isset( $caldera_forms_freemius ) ) {
+		// Include Freemius SDK.
+		require_once CFCORE_PATH . 'includes/freemius/start.php';
+		$caldera_forms_freemius = fs_dynamic_init( array(
+			'id'                  => '1767',
+			'slug'                => 'caldera-forms',
+			'type'                => 'plugin',
+			'public_key'          => 'pk_d8e6325777a98c1b3e0d8cdbfad1e',
+			'is_premium'          => false,
+			'has_addons'          => false,
+			'has_paid_plans'      => false,
+			'menu'                => array(
+				'slug'           => 'caldera-forms',
+				'account'        => false,
+				'support'        => false,
+				'contact'        => false,
+			),
+		) );
+		/**
+		 * Runs after Freemius loads
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param Freemius $caldera_forms_freemius
+		 */
+		do_action( 'caldera_forms_freemius_init', $caldera_forms_freemius );
+	}
+	return $caldera_forms_freemius;
 }
 
 //Load freemius
@@ -154,5 +146,5 @@ caldera_forms_freemius();
  * @return string
  */
 function caldera_forms_freemius_icon_path(){
-    return CFCORE_PATH . 'assets/build/images/new-icon.png';
+	return CFCORE_PATH . 'assets/build/images/new-icon.png';
 }

--- a/fields/advanced_file/field.php
+++ b/fields/advanced_file/field.php
@@ -47,8 +47,13 @@
 			$field['config']['allowed'][] = $mime;
 			$accept_tag[] = '.' . str_replace('|', ',.', $ext );
 		}
-		
+
 	}
+
+    if (in_array( 'audio/mpeg',$field['config']['allowed']  )) {
+        $field['config']['allowed'][] = 'audio/mp3';
+    }
+
 	$accept_tag = 'accept="' . esc_attr( implode(',', $accept_tag) ) . '"';
 
 	$field['config']['max_size'] = wp_max_upload_size();

--- a/fields/advanced_file/field.php
+++ b/fields/advanced_file/field.php
@@ -30,6 +30,8 @@
 			$field['config']['multi_upload_text'] = __( 'Add Files', 'caldera-forms' );
 		}
 	}
+
+	//Set allowed types
 	$accept_tag = array();
 	if( !empty( $field['config']['allowed'] ) ){
 		$allowed = array_map('trim', explode(',', trim( $field['config']['allowed'] ) ) );
@@ -38,6 +40,7 @@
 			$ext = trim( $ext, '.' );
 			$file_type = wp_check_filetype( 'tmp.'. $ext );
 			$field['config']['allowed'][] = $file_type['type'];
+			$field['config']['allowed'][] = $file_type['ext'];
 			$accept_tag[] = '.' . $ext;
 		}
 	}else{
@@ -50,8 +53,17 @@
 
 	}
 
-    if (in_array( 'audio/mpeg',$field['config']['allowed']  )) {
-        $field['config']['allowed'][] = 'audio/mp3';
+	//Fix allowed types
+    // @see https://github.com/CalderaWP/Caldera-Forms/issues/2471
+    if ( ! empty( $field['config']['allowed'] )) {
+        if (in_array('audio/mpeg', $field['config']['allowed'])) {
+            $field['config']['allowed'][] = 'audio/mp3';
+        }
+        $field['config']['allowed'] = array_unique($field['config']['allowed']);
+    }
+
+    if (! empty( $accept_tag)) {
+        $accept_tag = array_unique($accept_tag);
     }
 
 	$accept_tag = 'accept="' . esc_attr( implode(',', $accept_tag) ) . '"';


### PR DESCRIPTION
This PR set allowed file types for advanced file fields to include mime and if audio/mpeg (mp3) is in list, adds audio/mp3 since that's what browsers identify mp3s as.

Fixes #2471 