### PR TITLE
Fixed a significant performance issue with select2 fields.

### DIFF
--- a/assets/js/state/state.js
+++ b/assets/js/state/state.js
@@ -250,6 +250,9 @@ function CFState(formId, $ ){
 			});
 			calcVals[id] = findCalcVal( $( document.getElementById( id ) ) );
 			self.mutateState([$field.attr('id')],$field.val());
+			$field.trigger('cf.bind', {
+				field: $field.attr('id')
+			});
 
 			return true;
 		} else {
@@ -333,6 +336,10 @@ function CFState(formId, $ ){
 
 
 					self.mutateState(id,val);
+					
+					$field.trigger('cf.bind', {
+						field: $field.attr('id')
+					});
 
 				});
 				return true;

--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -131,34 +131,8 @@ jQuery( function($){
 	var opts = {};
 	<?php } ?>
 
-	// run a function no more than once every time the field needs to be initialized
-	// i.e either on page load or when the conditional field becomes visible
-	var run_on_init_add = function (field_id, init_func) {
-		var init = true;
-		// check if it's already added
-		var elem = $( '#' + field_id );
-		if ( elem.length ) {
-			init = false;
-			init_func( elem );
-		}
-		//TODO: for unconditional fields we don't need to do this
-		$(document).on( 'cf.add', function (event, field) {
-			if ( !init || field.field != field_id )
-				return;
-			var elem = $( '#' + field_id );
-			if ( !elem.length )
-				return;
-			init = false;
-			init_func( elem );
-		});
-		$(document).on( 'cf.remove', function (event, field) {
-			if ( field.field == field_id )
-				init = true;
-		});
-	};
-
-	run_on_init_add( '<?php echo $field_id; ?>', function (elem) {
-		elem.select2( opts );
+	$(document).on('cf.bind', '#<?php echo $field_id; ?>', function() {
+		$(this).select2( opts );
 	});
 });
 </script>

--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -131,9 +131,35 @@ jQuery( function($){
 	var opts = {};
 	<?php } ?>
 
-	$(document).on('cf.add', function(){
-		$('#<?php echo $field_id; ?>').select2( opts );
-	}).trigger('cf.add');
+	// run a function no more than once every time the field needs to be initialized
+	// i.e either on page load or when the conditional field becomes visible
+	var run_on_init_add = function (field_id, init_func) {
+		var init = true;
+		// check if it's already added
+		var elem = $( '#' + field_id );
+		if ( elem.length ) {
+			init = false;
+			init_func( elem );
+		}
+		//TODO: for unconditional fields we don't need to do this
+		$(document).on( 'cf.add', function (event, field) {
+			if ( !init || field.field != field_id )
+				return;
+			var elem = $( '#' + field_id );
+			if ( !elem.length )
+				return;
+			init = false;
+			init_func( elem );
+		});
+		$(document).on( 'cf.remove', function (event, field) {
+			if ( field.field == field_id )
+				init = true;
+		});
+	};
+
+	run_on_init_add( '<?php echo $field_id; ?>', function (elem) {
+		elem.select2( opts );
+	});
 });
 </script>
 <?php


### PR DESCRIPTION
#2697

The select2 fields were initialized over and over again whenever any other conditional field became visible. For large forms with many select2 and conditional fields, this could actually double the whole page load time.

This patch makes sure the select2 fields are initialized only once on load, and whenever they become visible if they're a conditional field.

TODO: The run_on_init_add function should probably go somewhere else so that it can be reused by custom fields and other user code ? Also, there might be even better ways of implementing this, for example we could avoid adding any event listeners for unconditional fields, but this already seems to be fast enough for now.