### PR TITLE
Fix typo in previews. <lable> should be <label>

### DIFF
--- a/fields/advanced_file/preview.php
+++ b/fields/advanced_file/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input type="file" class="preview-field-config" disabled="disabled" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<span class="help-block">{{caption}}</span>

--- a/fields/button/preview.php
+++ b/fields/button/preview.php
@@ -1,4 +1,4 @@
 <div class="preview-caldera-config-group">
-	{{#if config/label_space}}<lable class="control-label">&nbsp;</lable>{{/if}}
+	{{#if config/label_space}}<lable class="control-label">&nbsp;</label>{{/if}}
 	<button type="{{config/type}}" class="button" disabled="disabled">{{label}}</button>
 </div>

--- a/fields/calculation/preview.php
+++ b/fields/calculation/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		{{#if config/element}}<{{config/element}} class="{{config/classes}}">{{/if}}{{config/before}}0{{#if config/fixed}}.00{{/if}}{{config/after}}{{#if config/element}}</{{config/element}}>{{/if}}
 		<span class="help-block">{{caption}}</span>

--- a/fields/checkbox/preview.php
+++ b/fields/checkbox/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		{{#if config/option}}
 			{{#each config/option}}

--- a/fields/color_picker/preview.php
+++ b/fields/color_picker/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group cf-color-picker">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{/if}} type="text" style="max-width:100px;" class="preview-field-config minicolor-picker" data-type="color_picker" value="{{config/default}}"><span style="background-color: {{config/default}};" class="preview-color-selector" data-for="{{id}}"></span>
 		<span class="help-block">{{caption}}</span>

--- a/fields/credit_card_cvc/preview.php
+++ b/fields/credit_card_cvc/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="{{config/type_override}}" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/credit_card_exp/preview.php
+++ b/fields/credit_card_exp/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="{{config/type_override}}" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/credit_card_number/preview.php
+++ b/fields/credit_card_number/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="{{config/type_override}}" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/date_picker/preview.php
+++ b/fields/date_picker/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{/if}} type="text" style="max-width:100px;" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/dropdown/preview.php
+++ b/fields/dropdown/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">		
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>

--- a/fields/email/preview.php
+++ b/fields/email/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="email" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/file/preview.php
+++ b/fields/file/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input type="file" class="preview-field-config" disabled="disabled" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<span class="help-block">{{caption}}</span>

--- a/fields/number/preview.php
+++ b/fields/number/preview.php
@@ -1,7 +1,7 @@
 <?php
 ?>
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="number" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/paragraph/preview.php
+++ b/fields/paragraph/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<textarea {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} rows="{{config/rows}}" style="resize:none;" class="preview-field-config">{{config/default}}</textarea>
 		<span class="help-block">{{caption}}</span>

--- a/fields/phone/preview.php
+++ b/fields/phone/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="text" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/phone_better/preview.php
+++ b/fields/phone_better/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="text" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/radio/preview.php
+++ b/fields/radio/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		{{#if config/option}}
 			{{#each config/option}}

--- a/fields/range_slider/preview.php
+++ b/fields/range_slider/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		{{#if config/showval}}<div class="col-xs-9" style="margin: {{#if config/pollyfill}}2px{{else}}6px{{/if}} 0px;">{{else}}<div style="margin: {{#if config/pollyfill}}2px{{else}}6px{{/if}} 0px;">{{/if}}
 			<input id="{{id}}_rangeslider" type="range" data-trackcolor="{{config/trackcolor}}" data-color="{{config/color}}" data-handle="{{config/handle}}" data-handleborder="{{config/handleborder}}" min="{{config/min}}" max="{{config/max}}" step="{{config/step}}" value="{{config/default}}" style="width:100%">

--- a/fields/select2/field/preview.php
+++ b/fields/select2/field/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">		
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>

--- a/fields/star-rate/preview.php
+++ b/fields/star-rate/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<div id="{{id}}_stars_preview" style="color:{{config/track_color}};font-size:{{config/size}}px;"></div>
 		<span class="help-block">{{caption}}</span>

--- a/fields/states/preview.php
+++ b/fields/states/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">		
 		<select class="preview-field-config" {{#if hide_label}}placeholder="{{label}}"{{/if}}>
 		<option value=""></option>

--- a/fields/summary/preview.php
+++ b/fields/summary/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="url" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/text/preview.php
+++ b/fields/text/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="{{config/type_override}}" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>

--- a/fields/toggle_switch/preview.php
+++ b/fields/toggle_switch/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<div class="toggle_option_preview{{#is config/orientation value="vertical"}} toggle_vertical{{/is}}">
 		{{#each config/option}}

--- a/fields/url/preview.php
+++ b/fields/url/preview.php
@@ -1,5 +1,5 @@
 <div class="preview-caldera-config-group">
-	{{#unless hide_label}}<lable class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</lable>{{/unless}}
+	{{#unless hide_label}}<label class="control-label">{{label}}{{#if required}} <span style="color:#ff0000;">*</span>{{/if}}</label>{{/unless}}
 	<div class="preview-caldera-config-field">
 		<input {{#if hide_label}}placeholder="{{label}}"{{else}}placeholder="{{config/placeholder}}"{{/if}} type="url" class="preview-field-config" value="{{config/default}}">
 		<span class="help-block">{{caption}}</span>


### PR DESCRIPTION
The preview.php files for each control have a typo in the <label> HTML element.  

Also, Hi Josh. 