### PR TITLE
Change spelling of ceil function 

### DIFF
--- a/classes/field/util.php
+++ b/classes/field/util.php
@@ -220,7 +220,7 @@ class Caldera_Forms_Field_Util {
 			'asin',
 			'atan',
 			'atan2',
-			'ciel',
+			'ceil',
 			'cos',
 			'exp',
 			'floor',


### PR DESCRIPTION
Resolves #2555

When we prefix math functions with `Math.` ceil was not subsituted. Explained why here: https://github.com/CalderaWP/Caldera-Forms/issues/2555#issuecomment-437072813 This PR changes the spelling so it is correct.
