### PR TITLE
Use property with form object 

### DIFF
--- a/classes/api/forms.php
+++ b/classes/api/forms.php
@@ -260,21 +260,22 @@ class Caldera_Forms_API_Forms extends  Caldera_Forms_API_CRUD {
 
         $forms = Caldera_Forms_Forms::get_forms( $request[ 'details' ] );
 	    $prepared = array();
-        if( ! empty( $forms ) && $request[ 'full' ] ){
-            foreach( $forms as $id => $form ){
-	            try{
-		            $form = $this->form_object_factory( $id, $request );
-	            }catch ( Exception $e ){
-		           continue;
-	            }
-                $prepared[ $id ] = $this->prepare_form_for_response( $form, $request );
-            }
+		if( ! empty( $forms ) && $request[ 'full' ] ){
+		    foreach( $forms as $id => $form ){
+			    try{
+				    $this->form_object_factory( $id, $request );
+			    }catch ( Exception $e ){
+				   continue;
+			    }
+				$prepared[ $id ] = $this->prepare_form_for_response( $this->form, $request );
+		    }
 
-        }
+		}
 
         $response = new Caldera_Forms_API_Response( $prepared, 200, array( ) );
         $response->set_total_header( count( $forms ) );
         return $response;
+		
     }
 
     /**


### PR DESCRIPTION
Resolves #2843 

The method `form_object_factory` by design (questionable design by past Josh) sets the class property form and returns nothing, which was causing the error. So I'm passing $this->form on the line that was previously giving me the error.

