### PR TITLE
Fixed: zh_cn is not available in the catalog

### DIFF
--- a/assets/js/i18n/zh_cn.extra.js
+++ b/assets/js/i18n/zh_cn.extra.js
@@ -1,6 +1,6 @@
 // Validation errors messages for Parsley
 // Load this after Parsley
 
-Parsley.addMessages('zh-cn', {
+Parsley.addMessages('zh_cn', {
   dateiso: "请输入正确格式的日期 (YYYY-MM-DD)."
 });

--- a/assets/js/i18n/zh_cn.js
+++ b/assets/js/i18n/zh_cn.js
@@ -1,7 +1,7 @@
 // Validation errors messages for Parsley
 // Load this after Parsley
 
-Parsley.addMessages('zh-cn', {
+Parsley.addMessages('zh_cn', {
   defaultMessage: "不正确的值",
   type: {
     email:        "请输入一个有效的电子邮箱地址",
@@ -26,4 +26,4 @@ Parsley.addMessages('zh-cn', {
   equalto:        "输入值不同"
 });
 
-Parsley.setLocale('zh-cn');
+Parsley.setLocale('zh_cn');


### PR DESCRIPTION
This fixes a JavaScript error:

```
Uncaught Error: zh_cn is not available in the catalog
    at m.setLocale (parsley.min.js?ver=1.7.5.1:2)
    at i.window.Parsley.(/ABC/anonymous function) [as setLocale] (/wp-content/plugins/caldera-forms/assets/build/js/parsley.min.js?ver=1.7.5.1:3:15735)
    at (index):2060
```