### PR TITLE
Get CF2 FIle field to unhide with values correctly #2912

### DIFF
--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -299,11 +299,6 @@ export class CalderaFormsRender extends Component {
 	 */
 	subscribe(fieldIdAttr) {
 		const {state, props} = this;
-		if (!stateChangeSubscriptions.hasOwnProperty(fieldIdAttr)) {
-			stateChangeSubscriptions[fieldIdAttr] = this.getCfState()
-				.events()
-				.subscribe(fieldIdAttr, (newValue, fieldIdAttr) => this.setFieldValue(fieldIdAttr, newValue, false))
-		}
 
 		const conditionalEvents = [
 			'show',


### PR DESCRIPTION
Deleting this functions allows the CF2 File field to be unhidden with values correctly.
I ran jest and php tests and they passed

@Shelob9 as I mentioned in the commit description, I'm not sure we can leave this as I deleted the only function that mentioned stateChangeSubscriptions. 
Let me know what point I missed in order for me to rewrite the condition `if !stateChangeSubscriptions.hasOwnProperty(fieldIdAttr)) {` in a way that don't break the unhiding event of the field.

#2912