### PR TITLE
Use the correct function to determine if file should be added to media library

### DIFF
--- a/cf2/Fields/Handlers/FileUpload.php
+++ b/cf2/Fields/Handlers/FileUpload.php
@@ -99,7 +99,7 @@ class FileUpload
 			$upload = wp_handle_upload($file, [ 'test_form' => false, 'action' => 'foo' ]);
 
 			$this->uploader->removeFilter();
-			if ( \Caldera_Forms_Files::should_attach($this->field, $this->form) ) {
+			if ( \Caldera_Forms_Files::should_add_to_media_library($this->field) ) {
 				\Caldera_Forms_Files::add_to_media_library($upload, $this->field);
 			}
 

--- a/cf2/RestApi/File/CreateFile.php
+++ b/cf2/RestApi/File/CreateFile.php
@@ -135,8 +135,6 @@ class CreateFile extends File
 
         $response = rest_ensure_response([
             'control' => $controlCode,
-           // 'uploads' => $uploads,
-            //  'tr' => $transientApi->getTransient($controlCode)
         ]);
         $response->set_status(201);
 


### PR DESCRIPTION
This PR switches to using the function for checking if a file should attach to email to the one for determining if file should be added to media library in the conditional wrapping the function that uploads the file to media library.

To test this, I used the form I upload here: https://github.com/CalderaWP/Caldera-Forms/issues/2944#issuecomment-458675488

I checked that after submission the uploaded file was not in the media library. I also made sure it was still attach to the email (testing with mailhog) and that it did NOT show up as a link in the email body (its a private file).

Fixes #2944