### PR TITLE
Unhide a cf2 field with correct field value set

### DIFF
--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -121,6 +121,13 @@ export class CalderaFormsRender extends Component {
 		return this.getCfState().getState(fieldIdAttr);
 	}
 
+	/**
+	 * Get all fields values
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return {*}
+	 */
 	getFieldValues() {
 		const {fieldsToControl} = this.props;
 		const pickArray = (array, key) => {

--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -128,7 +128,7 @@ export class CalderaFormsRender extends Component {
 	 *
 	 * @return {*}
 	 */
-	getFieldValues() {
+	getAllFieldValues() {
 		const {fieldsToControl} = this.props;
 		const pickArray = (array, key) => {
 			return array.reduce(

--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -331,7 +331,8 @@ export class CalderaFormsRender extends Component {
 								const {eventType, fieldIdAttr} = eventData;
 								let {fieldValue} = eventData;
 								if(typeof fieldValue === 'undefined'){
-									fieldValue = this.state[fieldIdAttr];
+									const values = this.getAllFieldValues();
+									fieldValue = values[fieldIdAttr];
 								}
 								switch (eventType) {
 									case 'hide':

--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -324,7 +324,7 @@ export class CalderaFormsRender extends Component {
 								const {eventType, fieldIdAttr} = eventData;
 								let {fieldValue} = eventData;
 								if(typeof fieldValue === 'undefined'){
-									fieldValue = this.getFieldValues()
+									fieldValue = this.state[fieldIdAttr];
 								}
 								switch (eventType) {
 									case 'hide':

--- a/clients/render/index.js
+++ b/clients/render/index.js
@@ -72,7 +72,7 @@ domReady(function () {
 
 		jQuery(document).on('cf.ajax.request', (event, obj) => {
 			shouldBeValidating = true;
-			const values = theComponent.getFieldValues();
+			const values = theComponent.getAllFieldValues();
 			const cf2 = window.cf2[obj.formIdAttr];
 			const {displayFieldErrors,$notice,$form,fieldsBlocking} = obj;
 			if ('object' !== typeof cf2) {

--- a/clients/tests/unit/render/CalderaFormsRender.test.js
+++ b/clients/tests/unit/render/CalderaFormsRender.test.js
@@ -179,7 +179,7 @@ describe('Form render methods', () => {
 			/>
 		);
 
-		expect(typeof component.instance().getFieldValues()).toBe('object');
+		expect(typeof component.instance().getAllFieldValues()).toBe('object');
 
 	});
 
@@ -213,8 +213,8 @@ describe('Form render methods', () => {
 			}
 		];
 		component.instance().getCfState().mutateState( 'fld_12_1', 'foot' );
-		expect(component.instance().getFieldValues().fld_12_1).toBe('foot');
-		expect(component.instance().getFieldValues().fld_7480239_1).toBe(value);
+		expect(component.instance().getAllFieldValues().fld_12_1).toBe('foot');
+		expect(component.instance().getAllFieldValues().fld_7480239_1).toBe(value);
 
 	});
 


### PR DESCRIPTION
Fix for #2964 It seems that the getFieldValues was used to set a field value during hide/unhide process but it returns all fields values and creates an error when unhiding a field.

In this PR I set the field Value from the field state values