### PR TITLE
Enqueue clients/render/build/style.min.css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,8 +48,7 @@ module.exports = function (grunt) {
     [
         'pro',
         'privacy',
-        'blocks',
-        'render'
+        'blocks'
     ].forEach( (client) => {
        files_list.push( `clients/${client}/build/index.min.js` );
        files_list.push( `clients/${client}/build/style.min.css` );
@@ -158,8 +157,7 @@ module.exports = function (grunt) {
                     'assets/build/css/caldera-grid.min.css',
                     'assets/build/css/caldera-alert.min.css',
                     'assets/build/css/caldera-form.min.css',
-                    'assets/build/css/fields.min.css',
-                    'clients/render/build/style.min.css'
+                    'assets/build/css/fields.min.css'
                  ],
                 dest: 'assets/css/caldera-forms-front.css'
             },

--- a/classes/render/assets.php
+++ b/classes/render/assets.php
@@ -592,6 +592,7 @@ class Caldera_Forms_Render_Assets {
 		self::enqueue_script( 'validator' );
 		self::enqueue_script( 'init' );
 		self::enqueue_script( 'render' );
+		self::enqueue_style( 'render' );
 
 		$should_minify = self::should_minify();
 		if( $should_minify  ){


### PR DESCRIPTION
Enqueue render fields styles from clients/render and don't concatenate it to caldera-forms-font with Grunt

npm run build to test this

This fixes #2947 