### PR TITLE
Make sure cf2 is set before declaring cf2.formIdAttr in render/index.js

### DIFF
--- a/clients/render/index.js
+++ b/clients/render/index.js
@@ -74,7 +74,9 @@ domReady(function () {
 			shouldBeValidating = true;
 			const values = theComponent.getAllFieldValues();
 			const cf2 = window.cf2[obj.formIdAttr];
-			cf2.formIdAttr = obj.formIdAttr;
+			if(typeof cf2 !== "undefined" && cf2.length > 0){
+				cf2.formIdAttr = obj.formIdAttr;
+			}
 			const {displayFieldErrors,$notice,$form,fieldsBlocking} = obj;
 			if ('object' !== typeof cf2) {
 				return;


### PR DESCRIPTION
This caused an erro in ajax-core that prevented to submit forms when no cf2 field was set.
This fixes #2970 
