### PR TITLE
Don't run cf2 fields multi page validation if cf2 or cf2.field is mis…

### DIFF
--- a/assets/js/frontend-script-init.js
+++ b/assets/js/frontend-script-init.js
@@ -139,7 +139,7 @@ var cf_jsfields_init, cf_presubmit;
 			window = window || {};
 			var cf2 = 'object' === typeof window.cf2 && 'object' === typeof window.cf2[form_id] ? window.cf2[form_id] : null;
 			function getCf2Field(fieldIdAttr,formIdAttr){
-				if( ! cf2 ){
+				if( ! cf2 || ! cf2.fields ){
 					return false;
 				}
 
@@ -173,7 +173,7 @@ var cf_jsfields_init, cf_presubmit;
 					continue;
 				}
 
-				valid =  validateField($this_field,form_id,valid);
+				valid = validateField($this_field,form_id,valid);
 
 				if (true === valid) {
 					continue;

--- a/clients/render/index.js
+++ b/clients/render/index.js
@@ -101,7 +101,9 @@ domReady(function () {
 					}
 				});
 			} else {
-				obj.$form.data(fieldId, values[fieldId]);
+				if(typeof field !== "undefined"){
+					obj.$form.data(field.fieldId, values[field.fieldId]);
+				}
 			}
 
 		});


### PR DESCRIPTION
…sing

This adds cf2.fields to the condition that returns false if cf2 is missing. In other words, skip cf2 multi page validation process when cf2 or cf2.fields is missing.

Works for #2993 error from tests