### PR TITLE
Look for the fieldValue using the field Id instead of fieldIdAttr

### DIFF
--- a/caldera-core.php
+++ b/caldera-core.php
@@ -54,7 +54,7 @@ if ( !version_compare(PHP_VERSION, '5.6.0', '>=') ) {
 } else {
 	define('CFCORE_PATH', plugin_dir_path(__FILE__));
 	define('CFCORE_URL', plugin_dir_url(__FILE__));
-	define('CFCORE_VER', '1.8.0-alpha.1');
+	define( 'CFCORE_VER', '1.8.0-alpha.1' );
 	define('CFCORE_EXTEND_URL', 'https://api.calderaforms.com/1.0/');
 	define('CFCORE_BASENAME', plugin_basename(__FILE__));
 

--- a/clients/render/components/CalderaFormsRender.js
+++ b/clients/render/components/CalderaFormsRender.js
@@ -321,6 +321,8 @@ export class CalderaFormsRender extends Component {
 	 */
 	subscribe(fieldIdAttr) {
 		const {state, props} = this;
+		const fieldConfig = this.getFieldConfig(fieldIdAttr);
+		const {fieldId} = fieldConfig;
 		if (!stateChangeSubscriptions.hasOwnProperty(fieldIdAttr)) {
 			stateChangeSubscriptions[fieldIdAttr] = this.getCfState()
 				.events()
@@ -347,8 +349,9 @@ export class CalderaFormsRender extends Component {
 								let {fieldValue} = eventData;
 								if(typeof fieldValue === 'undefined'){
 									const values = this.getAllFieldValues();
-									fieldValue = values[fieldIdAttr];
+									fieldValue = values[fieldId];
 								}
+
 								switch (eventType) {
 									case 'hide':
 										this.setFieldShouldShow(fieldIdAttr, false, fieldValue);


### PR DESCRIPTION
getAllFieldValues returns an object using fieldId as key (not fieldIdAttr), I don't understand how it coud have worked in previous tests I made...

This is for #2996 