### PR TITLE
PHP 5.6 compat in dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "calderawp/caldera-forms-query" : "0.3.2",
         "calderawp/caldera-containers": "^0.2.0",
         "composer/installers": "^1.6",
-        "a5hleyrich/wp-queue": "^1.3"
+        "a5hleyrich/wp-queue": "^1.3",
+        "symfony/translation": "~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This requires  "symfony/translation": "~3.0" to stay php 5.6 compat, previously we had 4.0, which is PHP 7.1+. I fixed this on WordPress.org in 1.8.0 while shipping. This PR will prevent same error when releasing 1.8.1

#3017