### PR TITLE
Fix Datepicker styles

### DIFF
--- a/fields/date_picker/css/datepicker.css
+++ b/fields/date_picker/css/datepicker.css
@@ -101,7 +101,6 @@
 .cfdatepicker table tr td,
 .cfdatepicker table tr th {
   text-align: center;
-  /*width: 10px;*/
   height: 10px;
   border-radius: 4px;
   border: none;

--- a/fields/date_picker/css/datepicker.css
+++ b/fields/date_picker/css/datepicker.css
@@ -101,7 +101,7 @@
 .cfdatepicker table tr td,
 .cfdatepicker table tr th {
   text-align: center;
-  width: 10px;
+  /*width: 10px;*/
   height: 10px;
   border-radius: 4px;
   border: none;


### PR DESCRIPTION
Removed fixed width for calendar columns, that way the first and last columns in the calendar shows correctly two figures numbers

Work for #3030 