### PR TITLE
Bind calculation value on page load for data set from previous entry

### DIFF
--- a/assets/js/state/state.js
+++ b/assets/js/state/state.js
@@ -102,7 +102,7 @@ function CFState(formId, $ ){
 		}
 
 		if (calcVals.hasOwnProperty(id) ) {
-			if( false === calcVals[id] || null === calcVals[id] ){
+			if( false === calcVals[id] || null === calcVals[id] || 0 === calcVals[id] ){
 				//@TODO use let here, when ES6.
 				var _val = findCalcVal( $( document.getElementById( id ) ) );
 				if( isString( _val )  ) {


### PR DESCRIPTION
When default value is set from previous entry using cf_ee query parameter, the calculation values were not correctly bound to calculation and all set to 0.

This fixes #3146 