### PR TITLE
Put a real big warning on forms that wp isn't defined and form will not work (2)

### DIFF
--- a/assets/js/frontend-script-init.js
+++ b/assets/js/frontend-script-init.js
@@ -345,8 +345,7 @@ var cf_jsfields_init, cf_presubmit;
 window.addEventListener("load", function(){
 	(function( $ ) {
 		'use strict';
-		var wpDefined = undefined === typeof window.wp;
-
+		var wpUndefined = undefined === typeof window.wp;
 
 		window.CALDERA_FORMS = {};
 
@@ -363,7 +362,7 @@ window.addEventListener("load", function(){
 
 				 if ('object' === typeof CFFIELD_CONFIG[instance] ) {
 					$form = $( document.getElementById( form_id ));
-					 if( ! wpDefined ){
+					 if( wpUndefined ){
 						 $(  $form.data( 'target' ) ).append( '<div class="alert alert-warning">' + CFFIELD_CONFIG[instance].error_strings.wp_not_defined + '</div>' );
 					 }else{
                          if ( ! protocolChecked ) {


### PR DESCRIPTION
Rename wpDefined to wpUndefined (as true means wp is not defined) and change the condition that triggers the warning.

This replaces #3202 that has been merged too fast...