### PR TITLE
Fix window.cf2 is undefinded caused by ajax requests

### DIFF
--- a/assets/js/ajax-core.js
+++ b/assets/js/ajax-core.js
@@ -174,7 +174,9 @@ jQuery(function($){
                 });
 
 				//Check if any cf2 fields are blocking submit
-				var cf2 = window.cf2[ $form.attr( 'id' ) ];
+                if( 'object' === typeof  window.cf2 ){
+                    var cf2 = window.cf2[ $form.attr( 'id' ) ];
+                }
 				if( 'object' === typeof cf2 ){
 					if( cf2.hasOwnProperty( 'pending' ) && 0 !== cf2.pending.length ){
 						return false;


### PR DESCRIPTION
Copy of PR https://github.com/CalderaWP/Caldera-Forms/pull/3265 bt @PASAf

For #3262 

Thank you again @PASAf, I reproduced the PR against develop branch, yours was made against master.

This prevent errors when ajax request are made, precise case of easy pods ajax request that logged the error.