### PR TITLE
Prevent unnecessary update checks

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -429,7 +429,6 @@ class Caldera_Forms
 
 			// check update version
 			$db_version = get_option('CF_DB', 0);
-			update_option( 'CF_DB', 7 );
 			$force_update = false;
 
 			// ensure that admin can only force update

--- a/classes/forms.php
+++ b/classes/forms.php
@@ -175,21 +175,21 @@ class Caldera_Forms_Forms {
 		    static::$index = static::get_stored_forms();
         }
 
-        if ( false === $internal_only ) {
-            /**
-             * Runs after getting internal forms, use to add forms defined in file system
-             *
-             * @since unknown
-             *
-             * @param array $base_forms Forms saved in DB
-             */
-            $forms = apply_filters('caldera_forms_get_forms', static::$index);
-            if (!empty($forms) && is_array($forms)) {
-                foreach ($forms as $form_id => $form) {
-                    $forms[$form_id] = $form_id;
-                }
-            }
-        }
+		if ( false === $internal_only ) {
+			/**
+			 * Runs after getting internal forms, use to add forms defined in file system
+			 *
+			 * @since unknown
+			 *
+			 * @param array $base_forms Forms saved in DB
+			 */
+			$external_forms = apply_filters( 'caldera_forms_get_forms', array() );
+			if ( ! empty( $external_forms) && is_array( $external_forms ) ) {
+				foreach ( array_keys( $external_forms ) as $form_id ) {
+					static::$index[$form_id] = $form_id;
+				}
+			}
+		}
 
 
 		if( $with_details ){


### PR DESCRIPTION
Setting the CF_DB to the fixed value of 7 causes unnecessary update checks on every other page load and unnecessary update queries on every page load.