### PR TITLE
Fix programmatically created Form not working when there's a Form created through the UI

### DIFF
--- a/classes/forms.php
+++ b/classes/forms.php
@@ -175,6 +175,8 @@ class Caldera_Forms_Forms {
 		    static::$index = static::get_stored_forms();
         }
 
+        $forms = static::$index;
+
         if ( false === $internal_only ) {
             /**
              * Runs after getting internal forms, use to add forms defined in file system
@@ -183,7 +185,7 @@ class Caldera_Forms_Forms {
              *
              * @param array $base_forms Forms saved in DB
              */
-            $forms = apply_filters('caldera_forms_get_forms', static::$index);
+            $forms = apply_filters('caldera_forms_get_forms', $forms);
             if (!empty($forms) && is_array($forms)) {
                 foreach ($forms as $form_id => $form) {
                     $forms[$form_id] = $form_id;
@@ -193,10 +195,8 @@ class Caldera_Forms_Forms {
 
 
 		if( $with_details ){
-			$forms = self::add_details( static::$index );
-		}else{
-			$forms = static::$index;
-        }
+			$forms = self::add_details( $forms );
+		}
 
 		if( $orderby && ! empty( $forms ) ){
 			$forms = self::order_forms( $forms, $orderby );


### PR DESCRIPTION
Caldera relies on the `caldera_forms_get_forms` filter to provide an "existence" to the Forms that were created programmatically and does not exist in the database.

That filter is applied in `\Caldera_Forms_Forms::get_forms`: https://github.com/CalderaWP/Caldera-Forms/blob/master/classes/forms.php#L178-L199

It applies the filter at line 186, but overrides it again to the original value on line 198.

Despite that, methods such as `\Caldera_Forms::render_form` might continue working, because of a `!empty($forms)` assertion. Check line 4278 of `core.php`: https://github.com/CalderaWP/Caldera-Forms/blob/master/classes/core.php#L4278

That probably means that two bugs co-exist generating an erratic behavior. If `$forms` return empty, it will not try to check for the existence of the Form, thus will continue the processing and will actually output the form. If `$forms` contain anything (such as a form saved on the database), it will assert if the form ID we are trying to render exists. That will fail because the filter was overridden, so `render_form` will just return null.

This PR fixes the behavior that is overriding the filter `caldera_forms_get_forms`.

Original issue: https://github.com/CalderaWP/Caldera-Forms/issues/3345