### PR TITLE
Target correct file to generate <input> for Color Picker field

### DIFF
--- a/classes/field/input.php
+++ b/classes/field/input.php
@@ -62,7 +62,11 @@ class Caldera_Forms_Field_Input extends Caldera_Forms_Field_HTML{
 			$place_holder  = self::place_holder_string( $field, $field[ 'label' ] );
 		}
 
-		if( 'number' === $type ){
+		if('color_picker' === $type ){
+			$attrs[ 'class' ] = 'form-control minicolor-picker init_field_type miniColors';
+			$attrs[ 'type' ] = 'text';
+			$attrs[ 'data-type' ] = 'color_picker';
+		}elseif( 'number' === $type ){
 			foreach( array(
 				'min',
 				'max',

--- a/classes/fields.php
+++ b/classes/fields.php
@@ -585,7 +585,7 @@ class Caldera_Forms_Fields {
 				"description" => __( 'Color Picker', 'caldera-forms' ),
 				'icon'          => CFCORE_URL . 'assets/build/images/paint-brush.svg',
 				"category"    => __( 'Select', 'caldera-forms' ),
-				"file"        => CFCORE_PATH . "fields/generic-input.php",
+				"file"        => CFCORE_PATH . "fields/color_picker/field.php",
 				"setup"       => array(
 					"preview"  => CFCORE_PATH . "fields/color_picker/preview.php",
 					"template" => CFCORE_PATH . "fields/color_picker/setup.php",

--- a/classes/fields.php
+++ b/classes/fields.php
@@ -585,7 +585,7 @@ class Caldera_Forms_Fields {
 				"description" => __( 'Color Picker', 'caldera-forms' ),
 				'icon'          => CFCORE_URL . 'assets/build/images/paint-brush.svg',
 				"category"    => __( 'Select', 'caldera-forms' ),
-				"file"        => CFCORE_PATH . "fields/color_picker/field.php",
+				"file"        => CFCORE_PATH . "fields/generic-input.php",
 				"setup"       => array(
 					"preview"  => CFCORE_PATH . "fields/color_picker/preview.php",
 					"template" => CFCORE_PATH . "fields/color_picker/setup.php",


### PR DESCRIPTION
For #1683 

The color picker configuration used the generic-input.php file to generate the <input> for the color picker field when the color picker input works with color_picker/field.php