### PR TITLE
Ensure `\Caldera_Forms_Forms::get_forms:()` returns forms added on a filter.

### DIFF
--- a/classes/forms.php
+++ b/classes/forms.php
@@ -189,14 +189,14 @@ class Caldera_Forms_Forms {
                     $forms[$form_id] = $form_id;
                 }
             }
+
         }
 
+		$forms = isset($forms) && false === $internal_only ? $forms : static::$index;
 
 		if( $with_details ){
-			$forms = self::add_details( static::$index );
-		}else{
-			$forms = static::$index;
-        }
+			$forms = self::add_details( $forms );
+		}
 
 		if( $orderby && ! empty( $forms ) ){
 			$forms = self::order_forms( $forms, $orderby );
@@ -411,15 +411,11 @@ class Caldera_Forms_Forms {
 	 */
 	protected static function add_details( $forms ){
 	    if( empty( $forms ) ){
-	        return [];
+			return [];
         }
 
-        if( ! empty( $valid_forms = get_transient( self::$registry_cache_key ) ) ) {
-            return $valid_forms;
-        }else{
-            $valid_forms = [];
-        }
-		
+		$valid_forms = [];
+
 		foreach( $forms as $id => $form  ){
 			$_form = self::get_form( $id );
 			if( empty( $_form ) ){
@@ -442,9 +438,6 @@ class Caldera_Forms_Forms {
 				}else {
 					$valid_forms[ $id ][ $key ] = '';
 				}
-
-
-
 			}
 		}
 
@@ -460,13 +453,8 @@ class Caldera_Forms_Forms {
 			}
 		}
 
-		if ( ! empty( $valid_forms ) ) {
-			set_transient( self::$registry_cache_key, $valid_forms, HOUR_IN_SECONDS );
-		}
-
-		self::$registry_cache = $valid_forms;
-		return self::$registry_cache;
-
+		set_transient( self::$registry_cache_key, $valid_forms, HOUR_IN_SECONDS );
+		return $valid_forms;
 	}
 
 	/**

--- a/classes/forms.php
+++ b/classes/forms.php
@@ -410,10 +410,12 @@ class Caldera_Forms_Forms {
 	 * @return array
 	 */
 	protected static function add_details( $forms ){
-	    if( empty( $forms ) ){
+		if( empty( $forms ) ){
 			return [];
-        }
+		}
 
+		//Intentionally avoiding using form cache here.
+		//See: https://github.com/CalderaWP/Caldera-Forms/pull/3354
 		$valid_forms = [];
 
 		foreach( $forms as $id => $form  ){

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -70,22 +70,27 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 	 * @covers caldera_forms_get_forms filter
 	 * @covers Caldera_Forms_Forms::get_forms()
 	 *
-	 * @group now
 	 */
 	public function testFilterAddedForms()
 	{
-		//No forms beacuse second argument is true
+
+		//No forms because second argument is true, ignoring forms added on filter is expected.
 		$this->assertCount(0, Caldera_Forms_Forms::get_forms(FALSE, TRUE));
+		//Same number of forms if $with_details is true, was false in previous assertion
 		$this->assertCount(0, Caldera_Forms_Forms::get_forms(true,true));
 
-		//Three forms added on filter caldera_forms_get_forms in bootstrap.php
-		$this->assertCount(3, Caldera_Forms_Forms::get_forms(FALSE));
-		$this->assertCount(3, Caldera_Forms_Forms::get_forms(true,true));
+		//Four forms added on filter caldera_forms_get_forms in bootstrap.php
+		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
+		//Same number of forms if $with_details is true, was false in previous assertion
+		$this->assertCount(4, Caldera_Forms_Forms::get_forms(true,false));
 
 		//add one more form and check again
 		$this->import_contact_form();
-		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
-		
+		$this->assertCount(5, Caldera_Forms_Forms::get_forms(FALSE));
+		//Same number of forms if $with_details is true, was false in previous assertion
+		$this->assertCount(5, Caldera_Forms_Forms::get_forms(true ));
+
+
 	}
 
 

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -79,16 +79,16 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 		//Same number of forms if $with_details is true, was false in previous assertion
 		$this->assertCount(0, Caldera_Forms_Forms::get_forms(true,true));
 
-		//Four forms added on filter caldera_forms_get_forms in bootstrap.php
-		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
+		//Three forms added on filter caldera_forms_get_forms in bootstrap.php
+		$this->assertCount(3, Caldera_Forms_Forms::get_forms(FALSE));
 		//Same number of forms if $with_details is true, was false in previous assertion
-		$this->assertCount(4, Caldera_Forms_Forms::get_forms(true,false));
+		$this->assertCount(3, Caldera_Forms_Forms::get_forms(true,false));
 
 		//add one more form and check again
 		$this->import_contact_form();
-		$this->assertCount(5, Caldera_Forms_Forms::get_forms(FALSE));
+		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
 		//Same number of forms if $with_details is true, was false in previous assertion
-		$this->assertCount(5, Caldera_Forms_Forms::get_forms(true ));
+		$this->assertCount(4, Caldera_Forms_Forms::get_forms(true ));
 
 
 	}

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -69,10 +69,20 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 	 * @since 1.7.0
 	 * @covers caldera_forms_get_forms filter
 	 * @covers Caldera_Forms_Forms::get_forms()
+	 *
+	 * @group now
 	 */
 	public function testFilterAddedForms()
 	{
+		//No forms beacuse second argument is true
 		$this->assertCount(0, Caldera_Forms_Forms::get_forms(FALSE, TRUE));
+		//Three forms added on filter caldera_forms_get_forms in bootstrap.php
+		$this->assertCount(3, Caldera_Forms_Forms::get_forms(FALSE));
+		//add one more form and check again
+		$this->import_contact_form();
+		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
+
+
 	}
 
 	/**

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -76,14 +76,18 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 	{
 		//No forms beacuse second argument is true
 		$this->assertCount(0, Caldera_Forms_Forms::get_forms(FALSE, TRUE));
+		$this->assertCount(0, Caldera_Forms_Forms::get_forms(true,true));
+
 		//Three forms added on filter caldera_forms_get_forms in bootstrap.php
 		$this->assertCount(3, Caldera_Forms_Forms::get_forms(FALSE));
+		$this->assertCount(3, Caldera_Forms_Forms::get_forms(true,true));
+
 		//add one more form and check again
 		$this->import_contact_form();
 		$this->assertCount(4, Caldera_Forms_Forms::get_forms(FALSE));
-
-
+		
 	}
+
 
 	/**
 	 * Test forms list without details


### PR DESCRIPTION
This PR fixes #3345 

It also fixes #3341

When I test with this branch, I see the form added using a filter int he Gutenberg block, form entry viewer and widget.

I think I got both of the bugs that @Luc45 said ` co-exist generating an erratic behavior` [here](https://github.com/CalderaWP/Caldera-Forms/issues/3345#issue-492514529).

I prevented  the overwrite of `$forms` here:
https://github.com/CalderaWP/Caldera-Forms/pull/3354/files#diff-634fa6588d7d78d435ea1ea46e18563cR195-R199

I also prevented forms added on a filter from being removed here:
https://github.com/CalderaWP/Caldera-Forms/pull/3354/files#diff-634fa6588d7d78d435ea1ea46e18563cL417

Note, I am intentionally bypassing reading from caching of that variable. I'm not worried about the performance, I am worried about bugs caused by WHEN the filter runs.

Also, I expanded the test that SHOULD have been covering this filter, but didn't tests these situations. I left my assumptions as inline comments:
https://github.com/CalderaWP/Caldera-Forms/pull/3354/files#diff-8c0dd687d0ffb15b67072a3555cb2700L73

