### PR TITLE
Swap order of conditions to prevent PHP undefined index notice

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1413,7 +1413,7 @@ class Caldera_Forms
 			}
 		}
 		//If symbols array is not empty convert it to a string and return the string
-		if(is_array($symbols) && !empty($symbols)){
+		if(!empty($symbols) && is_array($symbols)){
 			$symbols = implode( ',', $symbols);
 			return $symbols;
 		} else {


### PR DESCRIPTION
For #3356 

The condition was checking the type before checking if not empty, swapping the order should prevent the notice.