### PR TITLE
Map wp-content/plugins into docker container 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
-version: "3.1"
+version: '3.1'
 
 services:
+
   wordpress:
     image: wordpress
     ports:
@@ -13,14 +14,12 @@ services:
       - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/caldera-forms
       - ./wp-content/plugins:/var/www/html/wp-content/plugins
-      - ./wp-content/uploads:/var/www/html/wp-content/uploads
   cli:
     image: wordpress:cli
     volumes:
-      - wordpress:/var/www/html
-      - .:/var/www/html/wp-content/plugins/caldera-forms
-      - ./wp-content/plugins:/var/www/html/wp-content/plugins
-      - ./wp-content/uploads:/var/www/html/wp-content/uploads
+    - wordpress:/var/www/html
+    - .:/var/www/html/wp-content/plugins/caldera-forms
+    - ./wp-content/plugins:/var/www/html/wp-content/plugins
     environment:
       WORDPRESS_DB_PASSWORD: example
       ABSPATH: /usr/src/wordpress/


### PR DESCRIPTION
Simple PR that changes the path mappings in docker-compose

To test, copy a plugin into `wp-content/plugins` and see if it works. Now I can install Ninja Forms!

#3358