### PR TITLE
Correct US States preset (Iowa) #3389

### DIFF
--- a/includes/presets/us_states.txt
+++ b/includes/presets/us_states.txt
@@ -12,7 +12,7 @@ HI|Hawaii
 ID|Idaho
 IL|Illinois
 IN|Indiana
-IAIowa
+IA|Iowa
 KS|Kansas
 KY|Kentucky
 LA|Louisiana


### PR DESCRIPTION
Issue #3389 

U.S. States preset for select boxes previously displayed Iowa as "IAIowa"; includes/presets/us_states.txt now correctly lists Iowa as "IA|Iowa"