### PR TITLE
Wait until document loaded to init select2 (autocomplete) field

### DIFF
--- a/fields/select2/field/field.php
+++ b/fields/select2/field/field.php
@@ -110,33 +110,35 @@ ob_start();
 }
 </style>
 <script>
-jQuery( function($){
-	<?php if( !empty( $bound ) ){ ?>
-	var opts = {
-		ajax: {
-			url: ajaxurl,
-			dataType: 'json',
-			quietMillis: 250,
-			data: function (term, page) {
-				return {
-					action : 'cf_filter_populate',
-					q: $('<?php echo $bound; ?>').val(), // search term
-					<?php if( !empty( $field['config']['easy_pod'] ) ){?>easy_pod : '<?php echo $field['config']['easy_pod']; ?>'<?php } ?>
-				};
-			},
-			results: function (data, page) {
+window.addEventListener('DOMContentLoaded', function(){
+	jQuery( function($){
+		<?php if( !empty( $bound ) ){ ?>
+		var opts = {
+			ajax: {
+				url: ajaxurl,
+				dataType: 'json',
+				quietMillis: 250,
+				data: function (term, page) {
+					return {
+						action : 'cf_filter_populate',
+						q: $('<?php echo $bound; ?>').val(), // search term
+						<?php if( !empty( $field['config']['easy_pod'] ) ){?>easy_pod : '<?php echo $field['config']['easy_pod']; ?>'<?php } ?>
+					};
+				},
+				results: function (data, page) {
 
-				return { results: data };
-			},
-			cache: true
-		}
-	};
-	<?php }else{ ?>	
-	var opts = {};
-	<?php } ?>
+					return { results: data };
+				},
+				cache: true
+			}
+		};
+		<?php }else{ ?>	
+		var opts = {};
+		<?php } ?>
 
-	$(document).on('cf.bind', '#<?php echo $field_id; ?>', function() {
-		$(this).select2( opts );
+		$(document).on('cf.bind', '#<?php echo $field_id; ?>', function() {
+			$(this).select2( opts );
+		});
 	});
 });
 </script>


### PR DESCRIPTION
Copied from https://github.com/CalderaWP/Caldera-Forms/pull/3412 that couldn't be rebased onto develop branch.

Resolves #3411  by waiting until the document loaded event to initialize the select2 field.

To test, install from the zip file and then add a select2 field with multiple options and test if it displays as autocomplete and generates no console errors.

[caldera-forms.zip](https://github.com/CalderaWP/Caldera-Forms/files/3973522/caldera-forms.zip)
