### PR TITLE
Clear cache in `\Caldera_Forms_Forms::create_form()`

### DIFF
--- a/classes/forms.php
+++ b/classes/forms.php
@@ -636,8 +636,10 @@ class Caldera_Forms_Forms {
 		$added = self::save_to_db( $newform, 'primary' );
 		if( ! $added ){
 			return false;
-
 		}
+
+		// Fixes https://github.com/CalderaWP/Caldera-Forms/issues/3455
+		self::clear_cache();
 
 		/**
 		 * Runs after form is created

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -265,4 +265,31 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 		$this->assertSame( 'round(2 * 2.3333)', $form['fields']['fld_60011111']['config']['manual_formula'] );
 	}
 
+    /**
+     * Is cache cleared after creating a form?
+     *
+     * @see https://github.com/CalderaWP/Caldera-Forms/issues/3455
+     *
+     * @covers Caldera_Forms_Forms::create_form()
+     * @covers Caldera_Forms_Forms::get_form()
+     * @covers Caldera_Forms_Forms::get_forms()
+     */
+	public function testCreateGetForms()
+    {
+        $form = \Caldera_Forms_Forms::create_form([
+            'name' => 'One'
+        ]);
+        $form2 = \Caldera_Forms_Forms::create_form([
+            'name' => 'Two'
+        ]);
+        //Query form all forms, check name is returned correctly for both forms
+        $forms = \Caldera_Forms_Forms::get_forms(true,true);
+        $this->assertSame($form['name'], $forms[$form['ID']]['name']);
+        $this->assertSame($form2['name'], $forms[$form2['ID']]['name']);
+
+        //Query for one form, check is name returned correctly
+        $this->assertSame($form['name'],  \Caldera_Forms_Forms::get_form($form['ID'])['name']);
+        $this->assertSame($form2['name'],  \Caldera_Forms_Forms::get_form($form2['ID'])['name']);
+    }
+
 }


### PR DESCRIPTION
This PR [clears the form cache](https://github.com/CalderaWP/Caldera-Forms/pull/3456/files#diff-634fa6588d7d78d435ea1ea46e18563cR642) after a form is created using `Caldera_Forms_Forms::create_form()` to resolve issue #3455

I also reproduced the issue with a test: https://github.com/CalderaWP/Caldera-Forms/pull/3456/files#diff-8c0dd687d0ffb15b67072a3555cb2700R277 It failed before the fix and passed after I put in the fix. 