### PR TITLE
Add forms and processor data services to cf2 container

### DIFF
--- a/cf2/CalderaFormsV2.php
+++ b/cf2/CalderaFormsV2.php
@@ -7,172 +7,177 @@ namespace calderawp\calderaforms\cf2;
 use calderawp\calderaforms\cf2\Fields\FieldTypeFactory;
 use calderawp\calderaforms\cf2\Transients\Cf1TransientsApi;
 use calderawp\calderaforms\cf2\Services\ServiceContract;
+
 class CalderaFormsV2 extends \calderawp\CalderaContainers\Service\Container implements CalderaFormsV2Contract
 {
 
-	/**
-	 * Path to main plugin file
-	 *
-	 * @since 1.8.0
-	 *
-	 * @var string
-	 */
-	protected $coreDirPath;
+    /**
+     * Path to main plugin file
+     *
+     * @since 1.8.0
+     *
+     * @var string
+     */
+    protected $coreDirPath;
 
-	/**
-	 * URL for main plugin file
-	 *
-	 * @since 1.8.0
-	 *
-	 * @var string
-	 */
-	protected $coreUrl;
+    /**
+     * URL for main plugin file
+     *
+     * @since 1.8.0
+     *
+     * @var string
+     */
+    protected $coreUrl;
 
-	/**
-	 * CalderaFormsV2 constructor.
-	 *
-	 * @since 1.8.0
-	 */
+    /**
+     * CalderaFormsV2 constructor.
+     *
+     * @since 1.8.0
+     */
     public function __construct()
     {
-        $this->singleton(Hooks::class, function(){
+        $this->singleton(Hooks::class, function () {
             return new Hooks($this);
         });
-        $this->singleton(Cf1TransientsApi::class, function(){
+        $this->singleton(Cf1TransientsApi::class, function () {
             return new Cf1TransientsApi();
         });
-		$this->singleton(FieldTypeFactory::class, function(){
-			return new FieldTypeFactory();
-		});
+        $this->singleton(FieldTypeFactory::class, function () {
+            return new FieldTypeFactory();
+        });
     }
 
-	/**
-	 * Register a service with container
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param ServiceContract $service The service to register
-	 *
-	 * @param boolean $isSingleton Is service a singleton?
-	 *
-	 * @return $this
-	 */
-    public function registerService( ServiceContract $service, $isSingleton ){
-		if (! $service->isSingleton()) {
-			$this->bind($service->getIdentifier(),  $service->register($this) );
-		}else{
-			$this->singleton($service->getIdentifier(), $service->register($this) );
-		}
-		return $this;
-	}
+    /**
+     * Register a service with container
+     *
+     * @param ServiceContract $service The service to register
+     *
+     * @param boolean $isSingleton Is service a singleton?
+     *
+     * @return $this
+     * @since 1.8.0
+     *
+     */
+    public function registerService(ServiceContract $service, $isSingleton)
+    {
+        if (!$service->isSingleton()) {
+            $this->bind($service->getIdentifier(), $service->register($this));
+        } else {
+            $this->singleton($service->getIdentifier(), $service->register($this));
+        }
+        return $this;
+    }
 
 
-	/**
-	 * Get service from container
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $identifier
-	 *
-	 * @return mixed
-	 */
-	public function getService($identifier){
-    	return $this->make($identifier);
-	}
+    /**
+     * Get service from container
+     *
+     * @param string $identifier
+     *
+     * @return mixed
+     * @since 1.8.0
+     *
+     */
+    public function getService($identifier)
+    {
+        return $this->make($identifier);
+    }
 
-	/**
-	 * Set path to main plugin file
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $coreDirPath
-	 *
-	 * @return $this
-	 */
+    /**
+     * Set path to main plugin file
+     *
+     * @param string $coreDirPath
+     *
+     * @return $this
+     * @since 1.8.0
+     *
+     */
     public function setCoreDir($coreDirPath)
-	{
-		$this->coreDirPath  = $coreDirPath;
-		return $this;
-	}
+    {
+        $this->coreDirPath = $coreDirPath;
+        return $this;
+    }
 
-	/**
-	 * Get path to main plugin file
-	 *
-	 * @since 1.8.0
-	 *
-	 * @return string
-	 */
-	public function getCoreDir(){
-    	if( is_string( $this->coreDirPath ) ){
-    		return $this->coreDirPath;
-		}
-		if( defined( 'CFCORE_PATH' ) ){
-			return CFCORE_PATH;
-		}
+    /**
+     * Get path to main plugin file
+     *
+     * @return string
+     * @since 1.8.0
+     *
+     */
+    public function getCoreDir()
+    {
+        if (is_string($this->coreDirPath)) {
+            return $this->coreDirPath;
+        }
+        if (defined('CFCORE_PATH')) {
+            return CFCORE_PATH;
+        }
 
-		return '';
-	}
+        return '';
+    }
 
-	/* @inheritdoc */
-	public function setCoreUrl($coreUrl)
-	{
-		$this->coreUrl = $coreUrl;
-		return $this;
-	}
+    /* @inheritdoc */
+    public function setCoreUrl($coreUrl)
+    {
+        $this->coreUrl = $coreUrl;
+        return $this;
+    }
 
-	/** @inheritdoc */
-	public function getCoreUrl()
-	{
-		if( $this->coreUrl ){
-			return $this->coreUrl;
-		}
+    /** @inheritdoc */
+    public function getCoreUrl()
+    {
+        if ($this->coreUrl) {
+            return $this->coreUrl;
+        }
 
-		if( defined( 'CFCORE_URL') ){
-			return CFCORE_URL;
-		}
+        if (defined('CFCORE_URL')) {
+            return CFCORE_URL;
+        }
 
-		return '';
-	}
+        return '';
+    }
 
-	/**
-	 * Get the singleton hooks instance
-	 *
-	 * @since 1.8.0
-	 *
-	 * @return \calderawp\CalderaContainers\Interfaces\ProvidesService|Hooks
-	 */
-    public function getHooks(){
+    /**
+     * Get the singleton hooks instance
+     *
+     * @return \calderawp\CalderaContainers\Interfaces\ProvidesService|Hooks
+     * @since 1.8.0
+     *
+     */
+    public function getHooks()
+    {
         return $this->make(Hooks::class);
     }
 
-	/**
-	 * Get our transients API
-	 *
-	 * @since 1.8.0
-	 *
-	 * @return \calderawp\CalderaContainers\Interfaces\ProvidesService|Cf1TransientsApi
-	 */
+    /**
+     * Get our transients API
+     *
+     * @return \calderawp\CalderaContainers\Interfaces\ProvidesService|Cf1TransientsApi
+     * @since 1.8.0
+     *
+     */
     public function getTransientsApi()
     {
-       return $this->make(Cf1TransientsApi::class );
+        return $this->make(Cf1TransientsApi::class);
     }
 
-	/**
-	 * Get field type factory
-	 *
-	 * @since 1.8.0
-	 *
-	 * @return FieldTypeFactory
-	 */
-	public function getFieldTypeFactory()
-	{
-		return $this->make(FieldTypeFactory::class );
-	}
+    /**
+     * Get field type factory
+     *
+     * @return FieldTypeFactory
+     * @since 1.8.0
+     *
+     */
+    public function getFieldTypeFactory()
+    {
+        return $this->make(FieldTypeFactory::class);
+    }
 
-	/** @inheritdoc */
-	public function getWpdb()
-	{
-		global $wpdb;
-		return $wpdb;
-	}
+    /** @inheritdoc */
+    public function getWpdb()
+    {
+        global $wpdb;
+        return $wpdb;
+    }
 }

--- a/cf2/Factories/Processor.php
+++ b/cf2/Factories/Processor.php
@@ -22,7 +22,7 @@ class Processor implements ProcessorFactory
      * @param array $form Saved settings for this form
      * @param array $fields Processor settings field configuration
      *
-     * @return \Caldera_Forms_Processor_Get_Data
+     * @return \Caldera_Forms_Processor_Data
      */
     public function dataFactory(array $config,array $form,array $fields){
         return new \Caldera_Forms_Processor_Get_Data($config,$form,$fields);

--- a/cf2/Factories/Processor.php
+++ b/cf2/Factories/Processor.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Factories;
+
+/**
+ * Class Processor
+ *
+ * Factory for Caldera Forms processors
+ */
+class Processor implements ProcessorFactory
+{
+
+    /**
+     * Factory for processor data
+     *
+     * @since 1.8.10
+     *
+     * Designed to be used in callback for processors
+     *
+     * @param array $config Saved settings for processor
+     * @param array $form Saved settings for this form
+     * @param array $fields Processor settings field configuration
+     *
+     * @return \Caldera_Forms_Processor_Get_Data
+     */
+    public function dataFactory(array $config,array $form,array $fields){
+        return new \Caldera_Forms_Processor_Get_Data($config,$form,$fields);
+    }
+
+}

--- a/cf2/Factories/ProcessorFactory.php
+++ b/cf2/Factories/ProcessorFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Factories;
+
+
+interface ProcessorFactory
+{
+    /**
+     * Factory for processor data
+     *
+     * @since 1.8.10
+     *
+     * Designed to be used in callback for processors
+     *
+     * @param array $config Saved settings for processor
+     * @param array $form Saved settings for this form
+     * @param array $fields Processor settings field configuration
+     *
+     * @return \Caldera_Forms_Processor_Get_Data
+     */
+    public function dataFactory(array $config,array $form,array $fields);
+}

--- a/cf2/Forms/Collection.php
+++ b/cf2/Forms/Collection.php
@@ -1,0 +1,98 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Forms;
+
+
+use calderawp\calderaforms\cf2\Exception;
+
+/**
+ * Class Collection
+ *
+ * Form collection implementation WITHOUT database.
+ */
+class Collection implements FormCollection
+{
+
+    /**
+     * The forms
+     *
+     * @since 1.8.10
+     *
+     * @var array
+     */
+    protected $forms;
+
+    /**
+     * Get all forms of collection
+     *
+     * @since 1.8.10
+     *
+     * @return array
+     */
+    public function getAll()
+    {
+        return  is_array($this->forms ) ? $this->forms : [];
+    }
+    /**
+     * Add a form to this collection
+     *
+     * @since 1.8.10
+     *
+     * @param array $form
+     * @return FormCollection
+     */
+    public function addForm(array $form)
+    {
+        $this->forms[$form['ID']] = $form;
+        return $this;
+    }
+
+    /**
+     * Get a form from this collection
+     *
+     * @since 1.8.10
+     *
+     * @param string $formId
+     * @return array
+     * @throws Exception
+     */
+    public function getForm(string $formId)
+    {
+        if (!$this->hasForm($formId)) {
+            throw new Exception("No form with ID $formId found");
+        }
+        return $this->forms[$formId];
+    }
+
+    /**
+     * Does collection have a form of this ID?
+     *
+     * @since 1.8.10
+     *
+     * @param string $formId
+     * @return bool
+     */
+    public function hasForm( string $formId)
+    {
+        return array_key_exists($formId, $this->forms);
+    }
+
+    /**
+     * Remove a form from the collection
+     *
+     * @since 1.8.10
+     *
+     * @param string $formId
+     * @return FormCollection
+     * @throws Exception
+     */
+    public function removeForm(string $formId)
+    {
+        if (!$this->hasForm($formId)) {
+            throw new Exception("No form with ID $formId found");
+        }
+        unset($this->forms[$formId]);
+        return $this;
+    }
+}

--- a/cf2/Forms/FormCollection.php
+++ b/cf2/Forms/FormCollection.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Forms;
+
+
+use calderawp\calderaforms\cf2\Exception;
+
+/**
+ * Interface FormCollection
+ *
+ * Describes a collection of saved forms
+ */
+interface FormCollection
+{
+    /**
+     * Get all forms of collection
+     *
+     * @return array
+     * @since 1.8.10
+     *
+     */
+    public function getAll();
+
+    /**
+     * Add a form to this collection
+     *
+     * @param array $form
+     * @return FormCollection
+     * @since 1.8.10
+     *
+     */
+    public function addForm(array $form);
+
+    /**
+     * Get a form from this collection
+     *
+     * @param string $formId
+     * @return array
+     * @throws Exception
+     * @since 1.8.10
+     *
+     */
+    public function getForm(string $formId);
+
+    /**
+     * Does collection have a form of this ID?
+     *
+     * @param string $formId
+     * @return bool
+     * @since 1.8.10
+     *
+     */
+    public function hasForm(string $formId);
+
+    /**
+     * Remove a form from the collection
+     *
+     * @param string $formId
+     * @return FormCollection
+     * @throws Exception
+     * @since 1.8.10
+     *
+     */
+    public function removeForm(string $formId);
+}

--- a/cf2/Services/FormsService.php
+++ b/cf2/Services/FormsService.php
@@ -39,7 +39,7 @@ class FormsService implements ServiceContract
     {
         $collection = new Collection();
         $forms = \Caldera_Forms_Forms::get_forms(true, false);
-        if (!$forms) {
+        if (!empty($forms)) {
             foreach ($forms as $form) {
                 if (isset($form['ID'])) {
                     $collection->addForm($form);

--- a/cf2/Services/FormsService.php
+++ b/cf2/Services/FormsService.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Services;
+
+
+use calderawp\calderaforms\cf2\CalderaFormsV2Contract;
+use calderawp\calderaforms\cf2\Forms\Collection;
+
+/**
+ * Class FormsService
+ *
+ * Service provider for forms. Abstracts over v1 forms API.
+ */
+class FormsService implements ServiceContract
+{
+
+    /**
+     * Identifier for this service
+     *
+     * @since 1.8.10
+     */
+    const IDENTIFIER = 'forms';
+
+    /** @inheritDoc */
+    public function getIdentifier()
+    {
+        return self::IDENTIFIER;
+    }
+
+    /** @inheritDoc */
+    public function isSingleton()
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function register(CalderaFormsV2Contract $container)
+    {
+        $collection = new Collection();
+        $forms = \Caldera_Forms_Forms::get_forms(true, false);
+        if (!$forms) {
+            foreach ($forms as $form) {
+                if (isset($form['ID'])) {
+                    $collection->addForm($form);
+                }
+            }
+        }
+        return $collection;
+
+    }
+
+}

--- a/cf2/Services/FormsService.php
+++ b/cf2/Services/FormsService.php
@@ -12,21 +12,9 @@ use calderawp\calderaforms\cf2\Forms\Collection;
  *
  * Service provider for forms. Abstracts over v1 forms API.
  */
-class FormsService implements ServiceContract
+class FormsService extends Service
 {
 
-    /**
-     * Identifier for this service
-     *
-     * @since 1.8.10
-     */
-    const IDENTIFIER = 'forms';
-
-    /** @inheritDoc */
-    public function getIdentifier()
-    {
-        return self::IDENTIFIER;
-    }
 
     /** @inheritDoc */
     public function isSingleton()

--- a/cf2/Services/ProcessorService.php
+++ b/cf2/Services/ProcessorService.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace calderawp\calderaforms\cf2\Services;
+
+
+use calderawp\calderaforms\cf2\CalderaFormsV2Contract;
+use calderawp\calderaforms\cf2\Factories\Processor;
+
+class ProcessorService extends Service
+{
+
+
+    /** @inheritDoc */
+    public function isSingleton()
+    {
+       return true;
+    }
+
+    /** @inheritDoc */
+    public function register(CalderaFormsV2Contract $container)
+    {
+        return new Processor();
+    }
+}

--- a/cf2/functions.php
+++ b/cf2/functions.php
@@ -45,7 +45,9 @@ function caldera_forms_v2_container_setup(\calderawp\calderaforms\cf2\CalderaFor
 	$container
 		->registerService(new \calderawp\calderaforms\cf2\Services\QueueService(), true)
 		->registerService(new \calderawp\calderaforms\cf2\Services\QueueSchedulerService(), true)
-        ->registerService(new \calderawp\calderaforms\cf2\Services\FormsService(), true );
+        ->registerService(new \calderawp\calderaforms\cf2\Services\FormsService(), true )
+        ->registerService(new \calderawp\calderaforms\cf2\Services\ProcessorService(), true );
+
 
 	//Run the scheduler with CRON
 	/** @var \calderawp\calderaforms\cf2\Jobs\Scheduler $scheduler */

--- a/cf2/functions.php
+++ b/cf2/functions.php
@@ -44,7 +44,8 @@ function caldera_forms_v2_container_setup(\calderawp\calderaforms\cf2\CalderaFor
 	//Register other services
 	$container
 		->registerService(new \calderawp\calderaforms\cf2\Services\QueueService(), true)
-		->registerService(new \calderawp\calderaforms\cf2\Services\QueueSchedulerService(), true);
+		->registerService(new \calderawp\calderaforms\cf2\Services\QueueSchedulerService(), true)
+        ->registerService(new \calderawp\calderaforms\cf2\Services\FormsService(), true );
 
 	//Run the scheduler with CRON
 	/** @var \calderawp\calderaforms\cf2\Jobs\Scheduler $scheduler */

--- a/classes/forms.php
+++ b/classes/forms.php
@@ -636,8 +636,10 @@ class Caldera_Forms_Forms {
 		$added = self::save_to_db( $newform, 'primary' );
 		if( ! $added ){
 			return false;
-
 		}
+
+		// Fixes https://github.com/CalderaWP/Caldera-Forms/issues/3455
+		self::clear_cache();
 
 		/**
 		 * Runs after form is created

--- a/processors/classes/data.php
+++ b/processors/classes/data.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Interface Caldera_Forms_Processor_Data
+ *
+ * Contract for Caldera_Forms_Processor_Get_Data
+ */
+interface Caldera_Forms_Processor_Data{
+    /**
+     * Add an error message to the errors property
+     *
+     * @param string $message Message for error
+     * @since 1.8.10
+     *
+     */
+    public function add_error($message);
+
+    /**
+     * Get the errors
+     *
+     * @return array|null
+     * @since 1.8.10
+     *
+     */
+    public function get_errors();
+
+    /**
+     * Get the values
+     *
+     * @return array|null
+     * @since 1.8.10
+     *
+     */
+    public function get_values();
+
+    /**
+     * Get prepared fields
+     *
+     * @return array|null
+     * @since 1.8.10
+     *
+     */
+    public function get_fields();
+
+    /**
+     * Get one value from the processor
+     *
+     * @param string $field Name of field
+     * @param mixed $default Optional. Default value to return if none set.
+     *
+     * @return mixed
+     * @since 1.8.10
+     *
+     */
+    public function get_value($field, $default = null);
+}

--- a/processors/classes/get_data.php
+++ b/processors/classes/get_data.php
@@ -9,7 +9,7 @@
  * @copyright 2015 CalderaWP LLC
  */
 
-class Caldera_Forms_Processor_Get_Data {
+class Caldera_Forms_Processor_Get_Data implements Caldera_Forms_Processor_Data{
 
 	/**
 	 * The values from current submission

--- a/tests/Integration/Caldera_Forms_FilesTest.php
+++ b/tests/Integration/Caldera_Forms_FilesTest.php
@@ -8,225 +8,226 @@ use calderawp\calderaforms\Tests\Util\Traits\TestsImages;
 class Caldera_Forms_FilesTest extends TestCase
 {
 
-	use TestsImages;
-	protected $field = [
-		'ID' => 'fld123',
-		'type' => 'file',
-		'config' => [
+    use TestsImages;
+    protected $field = [
+        'ID' => 'fld123',
+        'type' => 'file',
+        'config' => [
 
-		],
-	];
+        ],
+    ];
 
-	/** @inheritdoc */
-	public function tearDown()
-	{
-		$this->deleteTestCatFile();
-		parent::tearDown();
-	}
+    /** @inheritdoc */
+    public function tearDown()
+    {
+        $this->deleteTestCatFile();
+        parent::tearDown();
+    }
 
-	/**
-	 *
-	 * @since  1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::should_attach()
-	 */
-	public function testShould_attach()
-	{
-		$field = array_merge($this->field, [
-			'config' => [ 'attach' => true ],
-		]);
+    /**
+     *
+     * @since  1.8.0
+     *
+     * @covers Caldera_Forms_Files::should_attach()
+     */
+    public function testShould_attach()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['attach' => true],
+        ]);
 
-		//Is set to attatch
-		$this->assertTrue(
-			Caldera_Forms_Files::should_attach($field, [])
-		);
+        //Is set to attatch
+        $this->assertTrue(
+            Caldera_Forms_Files::should_attach($field, [])
+        );
 
-		//No value, default false
-		$this->assertFalse(
-			Caldera_Forms_Files::should_attach($this->field, [])
-		);
+        //No value, default false
+        $this->assertFalse(
+            Caldera_Forms_Files::should_attach($this->field, [])
+        );
 
-		$field = array_merge($this->field, [
-			'config' => [ 'attach' => false ],
-		]);
-	//False value
-		$this->assertFalse(
-			Caldera_Forms_Files::should_attach($field, [])
-		);
+        $field = array_merge($this->field, [
+            'config' => ['attach' => false],
+        ]);
+        //False value
+        $this->assertFalse(
+            Caldera_Forms_Files::should_attach($field, [])
+        );
 
-	}
+    }
 
-	/**
-	 *
-	 * @since  1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::is_private()
-	 */
-	public function testIs_private()
-	{
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => false ],
-		]);
+    /**
+     *
+     * @since  1.8.0
+     *
+     * @covers Caldera_Forms_Files::is_private()
+     */
+    public function testIs_private()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => false],
+        ]);
 
-		//Not in media library, is private
-		$this->assertTrue(
-			Caldera_Forms_Files::is_private($field)
-		);
+        //Not in media library, is private
+        $this->assertTrue(
+            Caldera_Forms_Files::is_private($field)
+        );
 
-		//Not in media library by default, so is private
-		$this->assertTrue(
-			Caldera_Forms_Files::is_private($this->field)
-		);
+        //Not in media library by default, so is private
+        $this->assertTrue(
+            Caldera_Forms_Files::is_private($this->field)
+        );
 
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => true ],
-		]);
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => true],
+        ]);
 
-		//In media library, so is not private
-		$this->assertFalse(
-			Caldera_Forms_Files::is_private($field)
-		);
-	}
+        //In media library, so is not private
+        $this->assertFalse(
+            Caldera_Forms_Files::is_private($field)
+        );
+    }
 
-	/**
-	 *
-	 * @since  1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::is_persistent()
-	 */
-	public function testIs_persistent()
-	{
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => true ],
-		]);
+    /**
+     *
+     * @since  1.8.0
+     *
+     * @covers Caldera_Forms_Files::is_persistent()
+     */
+    public function testIs_persistent()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => true],
+        ]);
 
-		//In media library, so is peristant
-		$this->assertTrue(
-			Caldera_Forms_Files::is_persistent($field)
-		);
-
-
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => false ],
-		]);
-
-		$this->assertFalse(
-			Caldera_Forms_Files::is_persistent($field)
-		);
+        //In media library, so is peristant
+        $this->assertTrue(
+            Caldera_Forms_Files::is_persistent($field)
+        );
 
 
-		$field = array_merge($this->field, [
-			'config' => [ 'persistent' => true ],
-		]);
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => false],
+        ]);
 
-		//Is peristant
-		$this->assertTrue(
-			Caldera_Forms_Files::is_persistent($field)
-		);
-
-		$field = array_merge($this->field, [
-			'config' => [ 'persistent' => false ],
-		]);
-
-		//Is not peristant
-		$this->assertFalse(
-			Caldera_Forms_Files::is_persistent($field)
-		);
-
-		//Is not peristant by default
-		$this->assertFalse(
-			Caldera_Forms_Files::is_persistent($this->field)
-		);
-
-	}
-
-	/**
-	 *
-	 * @since  1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::should_add_to_media_library()
-	 */
-	public function testShould_add_to_media_library()
-	{
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => true ],
-		]);
-
-		//add when true
-		$this->assertTrue(
-			Caldera_Forms_Files::should_add_to_media_library($field)
-		);
-		//not by default
-		$this->assertFalse(
-			Caldera_Forms_Files::should_add_to_media_library($this->field)
-		);
-
-		$field = array_merge($this->field, [
-			'config' => [ 'media_lib' => false ],
-		]);
-
-		//not when false
-		$this->assertFalse(
-			Caldera_Forms_Files::should_add_to_media_library($field)
-		);
-	}
-
-	/**
-	 *
-	 * @since 1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::get_max_upload_size()
-	 */
-	public function testGetMaxUploadSize()
-	{
-		$field = array_merge($this->field, [
-			'config' => [ 'max_upload' => 42 ],
-		]);
-		//returns saved value
-		$this->assertEquals( 42, Caldera_Forms_Files::get_max_upload_size($field ) );
-
-		$field = array_merge($this->field, [
-			'config' => [ 'max_upload' => '42' ],
-		]);
-		//always a string
-		$this->assertEquals( 42, Caldera_Forms_Files::get_max_upload_size($field ) );
-
-		//0 by default
-		$this->assertEquals( 0, Caldera_Forms_Files::get_max_upload_size($this->field ) );
-	}
-
-	/**
-	 **
-	 * @since 1.8.0
-	 *
-	 * @covers Caldera_Forms_Files::is_file_too_large()
-	 * @covers Caldera_Forms_Files::get_max_upload_size()
-	 */
-	public function testIfFileIsTooLarge(){
-		$field = array_merge($this->field, [
-			'config' => [ 'max_upload' => 42 ],
-		]);
-
-		//This file is larger than 42 bytes
-		$this->assertTrue(
-			Caldera_Forms_Files::is_file_too_large($field, $this->createSmallCat() )
-		);
+        $this->assertFalse(
+            Caldera_Forms_Files::is_persistent($field)
+        );
 
 
-		$field = array_merge($this->field, [
-			'config' => [ 'max_upload' => 42000000 ],
-		]);
+        $field = array_merge($this->field, [
+            'config' => ['persistent' => true],
+        ]);
 
-		//This file is smaller than 42000000 bytes
-		$this->assertFalse(
-			Caldera_Forms_Files::is_file_too_large($field, $this->createSmallCat() )
-		);
+        //Is peristant
+        $this->assertTrue(
+            Caldera_Forms_Files::is_persistent($field)
+        );
+
+        $field = array_merge($this->field, [
+            'config' => ['persistent' => false],
+        ]);
+
+        //Is not peristant
+        $this->assertFalse(
+            Caldera_Forms_Files::is_persistent($field)
+        );
+
+        //Is not peristant by default
+        $this->assertFalse(
+            Caldera_Forms_Files::is_persistent($this->field)
+        );
+
+    }
+
+    /**
+     *
+     * @since  1.8.0
+     *
+     * @covers Caldera_Forms_Files::should_add_to_media_library()
+     */
+    public function testShould_add_to_media_library()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => true],
+        ]);
+
+        //add when true
+        $this->assertTrue(
+            Caldera_Forms_Files::should_add_to_media_library($field)
+        );
+        //not by default
+        $this->assertFalse(
+            Caldera_Forms_Files::should_add_to_media_library($this->field)
+        );
+
+        $field = array_merge($this->field, [
+            'config' => ['media_lib' => false],
+        ]);
+
+        //not when false
+        $this->assertFalse(
+            Caldera_Forms_Files::should_add_to_media_library($field)
+        );
+    }
+
+    /**
+     *
+     * @since 1.8.0
+     *
+     * @covers Caldera_Forms_Files::get_max_upload_size()
+     */
+    public function testGetMaxUploadSize()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['max_upload' => 42],
+        ]);
+        //returns saved value
+        $this->assertEquals(42, Caldera_Forms_Files::get_max_upload_size($field));
+
+        $field = array_merge($this->field, [
+            'config' => ['max_upload' => '42'],
+        ]);
+        //always a string
+        $this->assertEquals(42, Caldera_Forms_Files::get_max_upload_size($field));
+
+        //0 by default
+        $this->assertEquals(0, Caldera_Forms_Files::get_max_upload_size($this->field));
+    }
+
+    /**
+     **
+     * @since 1.8.0
+     *
+     * @covers Caldera_Forms_Files::is_file_too_large()
+     * @covers Caldera_Forms_Files::get_max_upload_size()
+     */
+    public function testIfFileIsTooLarge()
+    {
+        $field = array_merge($this->field, [
+            'config' => ['max_upload' => 42],
+        ]);
+
+        //This file is larger than 42 bytes
+        $this->assertTrue(
+            Caldera_Forms_Files::is_file_too_large($field, $this->createSmallCat())
+        );
 
 
-		//No limits, all files are the right size.
-		$this->assertFalse(
-			Caldera_Forms_Files::is_file_too_large($this->field, $this->createSmallCat() )
-		);
-	}
+        $field = array_merge($this->field, [
+            'config' => ['max_upload' => 42000000],
+        ]);
+
+        //This file is smaller than 42000000 bytes
+        $this->assertFalse(
+            Caldera_Forms_Files::is_file_too_large($field, $this->createSmallCat())
+        );
+
+
+        //No limits, all files are the right size.
+        $this->assertFalse(
+            Caldera_Forms_Files::is_file_too_large($this->field, $this->createSmallCat())
+        );
+    }
 
 }

--- a/tests/Integration/EnvironmentTest.php
+++ b/tests/Integration/EnvironmentTest.php
@@ -16,4 +16,6 @@ class EnvironmentTest extends TestCase
     {
         $this->assertTrue(is_numeric(wp_insert_post(['post_title' => 'LOl', 'post_content' => 'LOL' ] ) ) );
     }
+
+
 }

--- a/tests/Integration/Factories/ProcessorTest.php
+++ b/tests/Integration/Factories/ProcessorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace calderawp\calderaforms\Tests\Integration\Factories;
+
+use calderawp\calderaforms\cf2\Factories\Processor;
+use calderawp\calderaforms\Tests\Integration\TestCase;
+use calderawp\calderaforms\Tests\Util\SubmissionHelpers;
+
+class ProcessorTest extends TestCase
+{
+    /** @inheritDoc */
+    public function tearDown()
+    {
+        //Delete forms after each test
+        $forms = \Caldera_Forms_Forms::get_forms(false, true);
+        if (!empty($forms)) {
+            foreach ($forms as $formId) {
+                \Caldera_Forms_Forms::delete_form($formId);
+            }
+        }
+        parent::tearDown();
+    }
+
+
+    /**
+     * Make sure that by setting field $_POST we can mock field data as other tests expect
+     *
+     * @since 1.8.10
+     *
+     * @group now
+     */
+    public function testTheTestAssumptions()
+    {
+        //Import form
+        $config = json_decode(file_get_contents(dirname(__FILE__,
+                3) . '/includes/forms/contact-form-autoresponder.json'));
+        $formId = \Caldera_Forms_Forms::import_form($this->recursiveCastArray($config), true);
+        //Set as global form
+        global $form;
+        $form = \Caldera_Forms_Forms::get_form($formId);
+
+        //Set two field values
+        $_POST = SubmissionHelpers::submission_data($formId, [
+            "fld_8768091" => "Roy",
+            "fld_9970286" => 'Sivan',
+        ]);
+
+        //Check both ways they can be accessed by \Caldera_Forms_Get_Data
+        $this->assertEquals(
+            'Roy',
+            \Caldera_Forms::do_magic_tags('%first_name%', null, $form)
+        );
+
+        $this->assertEquals(
+            'Roy',
+            \Caldera_Forms::get_field_data('fld_8768091', $form)
+        );
+
+        $this->assertEquals(
+            'Sivan',
+            \Caldera_Forms::do_magic_tags('%last_name%', null, $form)
+        );
+
+        $this->assertEquals(
+            'Sivan',
+            \Caldera_Forms::get_field_data('fld_9970286', $form)
+        );
+
+        $data = new \Caldera_Forms_Processor_Get_Data([
+            "one" => '%first_name%',
+            "two" => 'fld_9970286',
+            'three' => 'hard coded value'
+        ], $form, [
+            [
+                'id' => 'one',
+                'label' => 'one',
+                'magic' => true,
+            ],
+            [
+                'id' => 'two',
+                'label' => 'two',
+                'magic' => false,
+            ],
+            [
+                'id' => 'three',
+                'label' => 'three',
+                'magic' => true,
+            ],
+        ]);
+        $this->assertEquals('Roy', $data->get_value('one'));
+        $this->assertEquals('Sivan', $data->get_value('two'));
+        $this->assertEquals('hard coded value', $data->get_value('three'));
+
+    }
+
+    /**
+     * Test processor data factory
+     *
+     * @since 1.8.10
+     *
+     * @group now
+     */
+    public function testFactory()
+    {
+        $config = json_decode(file_get_contents(dirname(__FILE__,
+                3) . '/includes/forms/contact-form-autoresponder.json'));
+        $formId = \Caldera_Forms_Forms::import_form($this->recursiveCastArray($config), true);
+        global $form;
+        $form = \Caldera_Forms_Forms::get_form($formId);
+        $_POST = SubmissionHelpers::submission_data($formId, [
+            "fld_8768091" => "Roy",
+            "fld_9970286" => 'Sivan',
+        ]);
+
+        $factory = new Processor();
+        $data = $factory->dataFactory([
+            "one" => '%first_name%',
+            "two" => 'fld_9970286',
+            'three' => 'hard coded value'
+        ], $form, [
+            [
+                'id' => 'one',
+                'label' => 'one',
+                'magic' => true,
+            ],
+            [
+                'id' => 'two',
+                'label' => 'two',
+                'magic' => false,
+            ],
+            [
+                'id' => 'three',
+                'label' => 'three',
+                'magic' => true,
+            ],
+        ]);
+
+        $this->assertEquals('Roy', $data->get_value('one'));
+        $this->assertEquals('Sivan', $data->get_value('two'));
+        $this->assertEquals('hard coded value', $data->get_value('three'));
+
+    }
+
+
+}

--- a/tests/Integration/Features/ContainerServicesAreLoadedTest.php
+++ b/tests/Integration/Features/ContainerServicesAreLoadedTest.php
@@ -4,7 +4,11 @@
 namespace calderawp\calderaforms\Tests\Integration\Features;
 
 
+use calderawp\calderaforms\cf2\Factories\ProcessorFactory;
+use calderawp\calderaforms\cf2\Forms\FormCollection;
 use calderawp\calderaforms\cf2\Jobs\Scheduler;
+use calderawp\calderaforms\cf2\Services\FormsService;
+use calderawp\calderaforms\cf2\Services\ProcessorService;
 use calderawp\calderaforms\cf2\Services\QueueSchedulerService;
 use calderawp\calderaforms\cf2\Services\QueueService;
 use calderawp\calderaforms\Tests\Integration\TestCase;
@@ -24,13 +28,50 @@ class ContainerServicesAreLoadedTest extends TestCase
 		$this->assertEquals( 1, did_action( 'caldera_forms_core_init'));
 		$this->assertEquals( 1,did_action( 'caldera_forms_v2_init'));
 	}
-	/** @group now */
+
+    /**
+     * @since 1.8.0
+     *
+     * @covers \caldera_forms_v2_container_setup()
+     */
 	public function testHasQueueService(){
 		$this->assertInstanceOf( Queue::class, caldera_forms_get_v2_container()->getService(QueueService::class) );
 	}
 
-	/** @group now */
+    /**
+     * @since 1.8.0
+     *
+     * @covers \caldera_forms_v2_container_setup()
+     */
 	public function testHasQueueSchedulerService(){
 		$this->assertInstanceOf( Scheduler::class, caldera_forms_get_v2_container()->getService(QueueSchedulerService::class) );
 	}
+
+    /**
+     * @since 1.8.10
+    *
+     * @covers \caldera_forms_v2_container_setup()
+     */
+    public function testHasFormsService()
+    {
+        $this->assertInstanceOf( FormCollection::class,
+            caldera_forms_get_v2_container()
+                ->getService(FormsService::class )
+        );
+
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @group now
+     * @covers \caldera_forms_v2_container_setup()
+     */
+    public function testHasProcessorService()
+    {
+        $this->assertInstanceOf( ProcessorFactory::class,
+            caldera_forms_get_v2_container()
+                ->getService(ProcessorService::class )
+        );
+    }
 }

--- a/tests/Integration/Service/FormServiceTest.php
+++ b/tests/Integration/Service/FormServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+
+namespace calderawp\calderaforms\Tests\Integration\Service;
+
+
+use calderawp\calderaforms\cf2\Forms\FormCollection;
+use calderawp\calderaforms\cf2\Services\FormsService;
+use calderawp\calderaforms\Tests\Integration\TestCase;
+use SaturdayDrive\EmailCRM\CfBridge\Database\Forms;
+
+class FormServiceTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function tearDown()
+    {
+        //Delete forms after each test
+        $forms = \Caldera_Forms_Forms::get_forms(false, true);
+        if (!empty($forms)) {
+            foreach ($forms as $formId) {
+                \Caldera_Forms_Forms::delete_form($formId);
+            }
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
+     * @covers \calderawp\calderaforms\cf2\Services\FormsService::getIdentifier()
+     */
+    public function testRegister()
+    {
+        $container = $this->getContainer();
+        $container->registerService(new FormsService(), true);
+        $this->assertInstanceOf(FormsService::class, $container->getService(FormsService::IDENTIFIER));
+    }
+
+    /**
+     * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getAll()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
+     */
+    public function testGetForms()
+    {
+        $formId = \Caldera_Forms_Forms::save_form([
+            'ID' => \Caldera_Forms_Forms::create_unique_form_id(),
+            'name' => 'Salad Tables'
+        ]);
+        $form = \Caldera_Forms_Forms::get_form($formId);
+        $this->assertArrayHasKey('ID', $form);
+
+        $form2Id = \Caldera_Forms_Forms::save_form([
+            'ID' => \Caldera_Forms_Forms::create_unique_form_id(),
+            'name' => 'Dessert Forks'
+        ]);
+        $container = $this->getContainer();
+        $container->registerService(new FormsService(), true);
+        /** @var FormCollection $formService */
+        $formService = $container->getService(FormsService::IDENTIFIER);
+        $this->assertCount(2, $formService->getAll());
+        $this->assertSame('Dessert Forks', $formService->getAll()[$form2Id]['name']);
+        $this->assertSame('Salad Tables', $formService->getAll()[$formId]['name']);
+    }
+
+    /**
+     * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
+     */
+    public function testGetForm()
+    {
+        $formId = \Caldera_Forms_Forms::save_form([
+            'ID' => \Caldera_Forms_Forms::create_unique_form_id(),
+            'name' => 'Salad Tables'
+        ]);
+        $form = \Caldera_Forms_Forms::get_form($formId);
+        $this->assertArrayHasKey('ID', $form);
+
+        $form2Id = \Caldera_Forms_Forms::save_form([
+            'ID' => \Caldera_Forms_Forms::create_unique_form_id(),
+            'name' => 'Dessert Forks'
+        ]);
+        $container = $this->getContainer();
+        $container->registerService(new FormsService(), true);
+        /** @var FormCollection $formService */
+        $formService = $container->getService(FormsService::IDENTIFIER);
+        $this->assertCount(2, $formService->getAll());
+        $this->assertSame('Dessert Forks', $formService->getForm($form2Id)['name']);
+        $this->assertSame('Salad Tables', $formService->getForm($formId)['name']);
+    }
+}

--- a/tests/Integration/Service/FormServiceTest.php
+++ b/tests/Integration/Service/FormServiceTest.php
@@ -34,7 +34,7 @@ class FormServiceTest extends TestCase
     {
         $container = $this->getContainer();
         $container->registerService(new FormsService(), true);
-        $this->assertInstanceOf(FormsService::class, $container->getService(FormsService::IDENTIFIER));
+        $this->assertInstanceOf(FormCollection::class, $container->getService(FormsService::IDENTIFIER));
     }
 
     /**

--- a/tests/Integration/Service/FormServiceTest.php
+++ b/tests/Integration/Service/FormServiceTest.php
@@ -27,17 +27,7 @@ class FormServiceTest extends TestCase
     }
 
     /**
-     * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
-     * @covers \calderawp\calderaforms\cf2\Services\FormsService::getIdentifier()
-     */
-    public function testRegister()
-    {
-        $container = $this->getContainer();
-        $container->registerService(new FormsService(), true);
-        $this->assertInstanceOf(FormCollection::class, $container->getService(FormsService::IDENTIFIER));
-    }
-
-    /**
+     * @since 1.8.10
      * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
      * @covers \calderawp\calderaforms\cf2\Forms\Collection::getAll()
      * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
@@ -58,13 +48,15 @@ class FormServiceTest extends TestCase
         $container = $this->getContainer();
         $container->registerService(new FormsService(), true);
         /** @var FormCollection $formService */
-        $formService = $container->getService(FormsService::IDENTIFIER);
+        $formService = $container->getService(FormsService::class);
         $this->assertCount(2, $formService->getAll());
         $this->assertSame('Dessert Forks', $formService->getAll()[$form2Id]['name']);
         $this->assertSame('Salad Tables', $formService->getAll()[$formId]['name']);
     }
 
     /**
+     * @since 1.8.10
+     *
      * @covers \calderawp\calderaforms\cf2\Services\FormsService::register()
      * @covers \calderawp\calderaforms\cf2\Forms\Collection::getForm()
      * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
@@ -85,7 +77,7 @@ class FormServiceTest extends TestCase
         $container = $this->getContainer();
         $container->registerService(new FormsService(), true);
         /** @var FormCollection $formService */
-        $formService = $container->getService(FormsService::IDENTIFIER);
+        $formService = $container->getService(FormsService::class);
         $this->assertCount(2, $formService->getAll());
         $this->assertSame('Dessert Forks', $formService->getForm($form2Id)['name']);
         $this->assertSame('Salad Tables', $formService->getForm($formId)['name']);

--- a/tests/Integration/Service/ProcessorServiceTest.php
+++ b/tests/Integration/Service/ProcessorServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace calderawp\calderaforms\Tests\Integration\Service;
+
+use calderawp\calderaforms\cf2\Factories\ProcessorFactory;
+use calderawp\calderaforms\cf2\Services\ProcessorService;
+use calderawp\calderaforms\Tests\Integration\TestCase;
+
+class ProcessorServiceTest extends TestCase
+{
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Services\ProcessorService::isSingleton()
+     */
+    public function testIsSingleton()
+    {
+        $service = new ProcessorService();
+        $this->assertTrue($service->isSingleton());
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Services\ProcessorService::getIdentifier()
+     */
+    public function testGetIdentifier()
+    {
+        $this->assertTrue(is_string(
+            (new ProcessorService())->getIdentifier()
+        ));
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Services\ProcessorService::register()
+     */
+    public function testRegister()
+    {
+        $container = $this->getContainer();
+        $this->assertInstanceOf(ProcessorFactory::class, (new ProcessorService())->register($container));
+    }
+}

--- a/tests/Integration/SubmissionsWithFileFieldsTest.php
+++ b/tests/Integration/SubmissionsWithFileFieldsTest.php
@@ -318,8 +318,6 @@ class SubmissionsWithFileFieldsTest extends TestCase
 	 *
 	 * @covers \calderawp\calderaforms\cf2\Fields\Handlers\Cf1FileUploader::addFilter()
 	 * @covers \calderawp\calderaforms\cf2\Fields\Handlers\Cf1FileUploader::removeFilter()
-	 *
-	 * @group now
 	 */
 	public function testScheduleDelete(){
 

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -37,4 +37,25 @@ class TestCase extends \WP_UnitTestCase
         $form = null;
         unset($GLOBALS['form']);
     }
+
+    /**
+     * Recursively cast array or object to array
+     *
+     * @since 1.8.10
+     *
+     * @param $arrayOrObject
+     * @return array
+     */
+    protected function recursiveCastArray($arrayOrObject)
+    {
+        $arrayOrObject = (array) $arrayOrObject;
+        foreach ($arrayOrObject as $key => $value ){
+            if( is_array( $value ) || is_object( $value ) ){
+                $arrayOrObject[ $key ] = $this->recursiveCastArray( $value );
+            }
+
+        }
+        return $arrayOrObject;
+    }
+
 }

--- a/tests/Unit/Forms/CollectionTest.php
+++ b/tests/Unit/Forms/CollectionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace calderawp\calderaforms\Tests\Unit\Forms;
+
+use calderawp\calderaforms\cf2\Exception;
+use calderawp\calderaforms\cf2\Forms\Collection;
+use calderawp\calderaforms\Tests\Unit\TestCase;
+
+class CollectionTest extends TestCase
+{
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getAll()
+     */
+    public function testGetAll()
+    {
+        $forms = new Collection();
+        $forms->addForm([
+            'ID' => 'cf1',
+            'name' => 'Taco Pants'
+        ]);
+        $forms->addForm([
+            'ID' => 'cf2',
+            'name' => 'Taco Shirts'
+        ]);
+        $this->assertCount(2, $forms->getAll());
+        $this->assertEquals('Taco Shirts', $forms->getAll()['cf2']['name']);
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::hasForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
+     */
+    public function testHasForm()
+    {
+        $forms = new Collection();
+        $forms->addForm([
+            'ID' => 'cf1',
+            'name' => 'Taco Pants'
+        ]);
+        $this->assertFalse($forms->hasForm('cf2'));
+        $this->assertTrue($forms->hasForm('cf1'));
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::addForm()
+     */
+    public function testAddForm()
+    {
+        $forms = new Collection();
+        $forms->addForm([
+            'ID' => 'cf1',
+            'name' => 'Taco Pants'
+        ]);
+        $this->assertSame('Taco Pants', $forms->getForm('cf1'));
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::hasForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getForm()
+     */
+    public function testGetFormThrows()
+    {
+        $forms = new Collection();
+        $forms->addForm([
+            'ID' => 'cf1',
+            'name' => 'Taco Pants'
+        ]);
+        $this->expectException(Exception::class);
+        $forms->getForm('cf2');
+    }
+
+    /**
+     * @since 1.8.10
+     *
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::removeForm()
+     * @covers \calderawp\calderaforms\cf2\Forms\Collection::getAll()
+     */
+    public function testRemoveForm()
+    {
+        $forms = new Collection();
+        $forms->addForm([
+            'ID' => 'cf1',
+            'name' => 'Taco Pants'
+        ]);
+        $forms->addForm([
+            'ID' => 'cf2',
+            'name' => 'Taco Shirts'
+        ]);
+        $forms->removeForm('cf1');
+        $this->assertTrue($forms->hasForm('cf2'));
+        $this->assertFalse($forms->hasForm('cf1'));
+        $this->assertCount(1, $forms->getAll());
+        $this->expectException(Exception::class);
+        $forms->removeForm('cf1');
+    }
+
+}

--- a/tests/Unit/Forms/CollectionTest.php
+++ b/tests/Unit/Forms/CollectionTest.php
@@ -60,7 +60,7 @@ class CollectionTest extends TestCase
             'ID' => 'cf1',
             'name' => 'Taco Pants'
         ]);
-        $this->assertSame('Taco Pants', $forms->getForm('cf1'));
+        $this->assertSame('Taco Pants', $forms->getForm('cf1')['name']);
     }
 
     /**

--- a/tests/test-forms-api.php
+++ b/tests/test-forms-api.php
@@ -265,4 +265,31 @@ class Test_Caldera_Forms_API extends Caldera_Forms_Test_Case
 		$this->assertSame( 'round(2 * 2.3333)', $form['fields']['fld_60011111']['config']['manual_formula'] );
 	}
 
+    /**
+     * Is cache cleared after creating a form?
+     *
+     * @see https://github.com/CalderaWP/Caldera-Forms/issues/3455
+     *
+     * @covers Caldera_Forms_Forms::create_form()
+     * @covers Caldera_Forms_Forms::get_form()
+     * @covers Caldera_Forms_Forms::get_forms()
+     */
+	public function testCreateGetForms()
+    {
+        $form = \Caldera_Forms_Forms::create_form([
+            'name' => 'One'
+        ]);
+        $form2 = \Caldera_Forms_Forms::create_form([
+            'name' => 'Two'
+        ]);
+        //Query form all forms, check name is returned correctly for both forms
+        $forms = \Caldera_Forms_Forms::get_forms(true,true);
+        $this->assertSame($form['name'], $forms[$form['ID']]['name']);
+        $this->assertSame($form2['name'], $forms[$form2['ID']]['name']);
+
+        //Query for one form, check is name returned correctly
+        $this->assertSame($form['name'],  \Caldera_Forms_Forms::get_form($form['ID'])['name']);
+        $this->assertSame($form2['name'],  \Caldera_Forms_Forms::get_form($form2['ID'])['name']);
+    }
+
 }


### PR DESCRIPTION
Resolves #3463 by adding and binding to the cf2 container:

- [x] A forms service that can get and update forms.
- [x] A factory for Caldera_Forms_Processor_Get_Data objects
