### PR TITLE
Set minum WordPress version

### DIFF
--- a/caldera-core.php
+++ b/caldera-core.php
@@ -43,16 +43,14 @@ if ( !version_compare(PHP_VERSION, '5.6.0', '>=') ) {
 	add_shortcode('caldera_form', 'caldera_forms_fallback_shortcode');
 	add_shortcode('caldera_form_modal', 'caldera_forms_fallback_shortcode');
 	add_action('admin_notices', 'caldera_forms_php_version_nag');
-} elseif ( !version_compare($wp_version, '4.7.0', '>=') ) {
-	function caldera_forms_wp_version_nag()
-	{
+} elseif ( !version_compare($wp_version, '5.0.0', '>=') ) {
+	function caldera_forms_wp_version_nag(){
 		?>
-        <div class="notice notice-error">
-            <p>
-				<?php _e('Your version of WordPress is incompatible with Caldera Forms and can not be used.',
-					'caldera-forms'); ?>
-            </p>
-        </div>
+		<div class="notice notice-error">
+		    <p>
+			<?php _e('Your version of WordPress is incompatible with Caldera Forms and can not be used.', 'caldera-forms'); ?>
+		    </p>
+		</div>
 		<?php
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Caldera Forms - More Than Contact Forms ===
 Contributors: Shelob9, Desertsnowman, christiechirinos, andrewza, nahuelmahe
 Tags: form, contact form, forms, form creator, form manager, mailchimp, paypal, stripe, login, payment, forms manager, forms creation
-Requires at least: 4.7
-Tested up to: 5.3
+Requires at least: 5.1
+Tested up to: 5.4
 Stable tag: 1.8.9
 License: GPLv2
 Requires PHP: 5.6


### PR DESCRIPTION
Fixes #3205

Two changes:

- Do not fully load plugin if WordPress version is LESS than 5.0.
- Show that plugin requires WordPress 5.1 or later.