### PR TITLE
Check that system_values[type] is not null

### DIFF
--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -1483,7 +1483,7 @@ rebind_field_bindings = function(){
                 }
 
                 for(var t = 0; t<types.length; t++){
-                    if( system_values[type].tags && system_values[type].tags[types[t]]){
+                    if( system_values[type] !== null && system_values[type].tags && system_values[type].tags[types[t]]){
 
                         for( var instance = 0; instance < type_instances.length; instance++){
 


### PR DESCRIPTION
For #3474 

Check that system_values[type] is not null to prevent errors when loading a page that is not set variables 