### PR TITLE
Re URL encode the URL variables when using a redirection processor

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1018,11 +1018,15 @@ class Caldera_Forms
 							parse_str($redirect['query'], $redirect['query']);
 							$base_redirect = explode('?', $base_redirect, 2);
 							$query_vars = array_merge($redirect['query'], $query_vars);
-							$redirect = add_query_arg($query_vars, $base_redirect[0]);
-						} else {
-							$redirect = add_query_arg($query_vars, $base_redirect);
+							$base_redirect = $base_redirect[0];
 						}
-
+						
+						// Re urlencode query vars after they were parsed in this function
+						foreach($query_vars as $var_names => $var_values){
+							$query_vars[$var_names] = urlencode($var_values);
+						}
+						$redirect = add_query_arg($query_vars, $base_redirect);
+						
 						return $redirect;
 					}
 				}

--- a/tests/test-do-redirect.php
+++ b/tests/test-do-redirect.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Test the do_redirect function
+ *
+ * @package   Caldera_Forms
+ * @author    Nico Figueira <nico@saturdaydrive.com>
+ * @license   GPL-2.0+
+ * @link
+ * @copyright 2016 CalderaWP LLC
+ */
+class Test_Caldera_Forms_Do_Redirect extends Caldera_Forms_Test_Case
+{
+    /**
+     * Test that query variable are returned URL encoded when using a redirection processor
+     *
+     * @since 1.8.10
+     *
+     */
+    public function test_query_variable_return_encoded(){
+        $form =  $this->mock_form;
+        //Add the redirection processor
+        $form["processors"]["fp_49138757"] = [
+            "ID" => "fp_49138757",
+            "runtimes" => [
+                "insert"    =>    1
+            ],
+            "type"  =>   "form_redirect",
+            "config"    =>   [
+                "url"   =>  "/caldera-forms-test-2",
+                "message"  => "go"
+            ],
+            "conditions"   => []
+        ];
+        //Set the $referrer as it would come in with a passback variable named first_name using data from a text field that was input with "Tamekah { + ? = ; : ù % > < { + kù" as value
+        $referrer = "/caldera-forms-test/?cf_su=1&cf_id=59&first_name=Tamekah+%7B+%2B+%3F+%3D+%3B+%3A+%C3%B9+%25+%3E+%3C+%7B+%2B+k%C3%B9";
+        //Process do_redirect()
+        $redirect = caldera_forms::do_redirect($referrer,$form, "159");
+
+        //We can't look for ? or % or + but the failing test would return characters like ; : ù > < { in $redirect
+        $this->assertTrue( strpos($redirect, "{") === false );
+        $this->assertTrue( strpos($redirect, ":") === false );
+        $this->assertTrue( strpos($redirect, ";") === false );
+        $this->assertTrue( strpos($redirect, "<") === false );
+        $this->assertTrue( strpos($redirect, "ù") === false );
+        $this->assertTrue( strpos($redirect, "Tamekah") === 42 );
+        $this->assertTrue( strpos($redirect, "k") === 46 );
+    }
+
+}


### PR DESCRIPTION
For #3482 

It appears the redirection processor parses the query args to remove the cf_su element but didn't encode them again.