### PR TITLE
Do not parse magic tags for variables if no magic tags

### DIFF
--- a/assets/js/edit.js
+++ b/assets/js/edit.js
@@ -1173,7 +1173,7 @@ jQuery(document).ready(function($){
             fieldtype.push('vars');
             for( var ft = 0; ft < fieldtype.length; ft++){
                 for( var tp in system_values ){
-                    if(typeof system_values[tp].tags === 'undefined' || typeof system_values[tp].tags[fieldtype[ft]] === 'undefined'){
+                    if( ! system_values[tp] || typeof system_values[tp].tags === 'undefined' || typeof system_values[tp].tags[fieldtype[ft]] === 'undefined'){
                         continue;
                     }
 


### PR DESCRIPTION
Fixes #3492 

This PR aborts the loop to build magic tags based on variables if there are no variables. 

To test:

* Create new form.
* Try to add a magic tag in a magic tag enabled field and ensure it works as expected with the dropdown.
* Add a variable.
* Confirm that they still show in magic tag selector when present.