### PR TITLE
Use rawurlencode()

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1023,7 +1023,7 @@ class Caldera_Forms
 						
 						// Re urlencode query vars after they were parsed in this function
 						foreach($query_vars as $var_names => $var_values){
-							$query_vars[$var_names] = urlencode($var_values);
+							$query_vars[$var_names] = rawurlencode($var_values);
 						}
 						$redirect = add_query_arg($query_vars, $base_redirect);
 						


### PR DESCRIPTION
Fixes **Warning:** urlencode() should only be used when dealing with legacy applications rawurlencode() should now be used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html