### PR TITLE
Use commnent black list for anti-spam 

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -3096,12 +3096,29 @@ class Caldera_Forms
 			$future_fields = $_POST['_cf_future'];
 		}
 
+		//https://developer.wordpress.org/reference/functions/wp_blacklist_check/
+        //https://halfelf.org/2018/spam-your-blacklist/amp/?__twitter_impression=true
+        $bad_words = explode( "\n", get_option( 'blacklist_keys' ) );
 
 		// start brining in entries
 		foreach ($form['fields'] as $field_id => $field) {
 
 			$entry = self::get_field_data($field_id, $form);
+            if( empty( $entry) && ! empty( $bad_words )) {
+                foreach ( $bad_words as $bad_word ) {
+                    $bad_word = trim( $bad_word );
 
+                    // Skip empty lines.
+                    if ( empty( $bad_word ) ) {
+                        continue;
+                    }
+
+                    ///Contains blacklisted Word
+                    if ( false !== strpos( $entry, $bad_word ) ) {
+                        $entry = new WP_Error( 400, __( 'This field contains a word that has been blocked.', 'caldera-forms' ) );
+                    }
+                }
+            }
 			if (is_wp_error($entry)) {
 				$transdata['fields'][$field_id] = $entry->get_error_message();
 			} else {


### PR DESCRIPTION
#2880

## What Has Changed

I created a new method in the Caldera_Forms class that gets the list of bad words from WordPress. It has a filter so end users can customize. I then copied logic from here https://gist.github.com/them-es/7c8a120ac868f5c4fc474e53a1266c83 to the loop where fields are validated.

## How to test

I'm not sure yet. But I think adding words to the block list and submitting form with those words in the fields.

* https://github.com/splorp/wordpress-comment-blacklist
* https://themeisle.com/blog/stop-comment-spam-on-wordpress/

