### PR TITLE
Save Forms via API

### DIFF
--- a/classes/api/crud.php
+++ b/classes/api/crud.php
@@ -253,9 +253,7 @@ abstract class Caldera_Forms_API_CRUD implements Caldera_Forms_API_Route
      */
     public function update_item(WP_REST_Request $request)
     {
-
-        return $this->not_yet_response();
-           
+        return $this->not_yet_response(); 
     }
 
     /**

--- a/classes/api/crud.php
+++ b/classes/api/crud.php
@@ -254,7 +254,7 @@ abstract class Caldera_Forms_API_CRUD implements Caldera_Forms_API_Route
     public function update_item(WP_REST_Request $request)
     {
 
-        \Caldera_Forms_API_Forms::save_form( $request );
+        return $this->not_yet_response();
            
     }
 

--- a/classes/api/crud.php
+++ b/classes/api/crud.php
@@ -253,7 +253,7 @@ abstract class Caldera_Forms_API_CRUD implements Caldera_Forms_API_Route
      */
     public function update_item(WP_REST_Request $request)
     {
-        return $this->not_yet_response(); 
+        return $this->not_yet_response();
     }
 
     /**

--- a/classes/api/crud.php
+++ b/classes/api/crud.php
@@ -253,7 +253,9 @@ abstract class Caldera_Forms_API_CRUD implements Caldera_Forms_API_Route
      */
     public function update_item(WP_REST_Request $request)
     {
-        return $this->not_yet_response();
+
+        \Caldera_Forms_API_Forms::save_form( $request );
+           
     }
 
     /**

--- a/classes/api/forms.php
+++ b/classes/api/forms.php
@@ -113,7 +113,7 @@ class Caldera_Forms_API_Forms extends  Caldera_Forms_API_CRUD {
      * 
      * @since 1.9.0
      */
-	public static function save_form(\WP_REST_Request $request){
+	public function save_form(\WP_REST_Request $request){
         $saved = Caldera_Forms_Admin::save_a_form(array_merge(['ID' => $request['form_id']],$request['config']));
         if( ! $saved ){
            return new \WP_Error(500,__('Not saved', 'caldera-forms'));

--- a/classes/api/forms.php
+++ b/classes/api/forms.php
@@ -113,7 +113,7 @@ class Caldera_Forms_API_Forms extends  Caldera_Forms_API_CRUD {
      * 
      * @since 1.9.0
      */
-	public function save_form(\WP_REST_Request $request){
+	public static function save_form(\WP_REST_Request $request){
         $saved = Caldera_Forms_Admin::save_a_form(array_merge(['ID' => $request['form_id']],$request['config']));
         if( ! $saved ){
            return new \WP_Error(500,__('Not saved', 'caldera-forms'));

--- a/classes/api/forms.php
+++ b/classes/api/forms.php
@@ -49,7 +49,7 @@ class Caldera_Forms_API_Forms extends  Caldera_Forms_API_CRUD {
         ];
 
 		//Re-register them
-        register_rest_route($namespace, $this->id_endpoint_url(), array_values( $this->id_route() ),true );
+        register_rest_route($namespace, $this->id_endpoint_url(), array_values( $id_route ),true );
 
 
         register_rest_route( $namespace, $this->id_endpoint_url() . '/revisions',

--- a/clients/form-builder/index.js
+++ b/clients/form-builder/index.js
@@ -69,6 +69,12 @@ const FieldConditionalSelectors = () => {
  * @since 1.9.0
  */
 const HandleSave = ({ jQuery, formId }) => {
+
+	//Reset formId if undefined
+	if(typeof formId === "undefined"){
+		formId = CF_ADMIN.form.ID;
+	}
+
 	//Get conditionals
 	const { conditionals, hasConditionals } = React.useContext(
 		ConditionalsContext


### PR DESCRIPTION
I could reproduce an issue saving the form when testing PR #3576 described in issue #3570. 

This is a branch created from #3576 and the PR is created against #3576. 

This just intends to illustrate the issue and makes saving form process work (along with privacy settings and entries edition) but I believe this is not the intended way of having the Forms saved.

