### PR TITLE
Automate building zip files on when tagged

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,0 +1,41 @@
+name: ZIP
+
+push:
+    tags:
+      - "*"
+  release:
+    types: [published]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install PHP dependencies, optimized
+      run: composer install --no-dev -o
+
+    - name: Install JS dependencies
+      run: yarn
+
+    - name: Build assets for release
+      run: yarn build
+    # MUST set in package.json to same as tag name before pushing tag
+    - name: Set version number 
+      run: yarn version:number
+    - name: Create build
+      run: yarn package
+    - name: Create ZIP
+        uses: papeloto/action-zip@v1
+        with:
+          files: assets/ cf2/ classes/ fields/ languages/ vendor/ processors/ sendwp/ ui/ caldera-core.php readme.txt LICENSE
+          recursive: false
+          dest: caldera-forms-${{ github.ref }}.zip
+    - name: Upload ZIP to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: caldera-forms-${{ github.ref }}.zip
+        tag: ${{ github.ref }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,41 +1,45 @@
 name: ZIP
 
-push:
+on:
+  push:
     tags:
       - "*"
   release:
-    types: [published]
+    types:
+      - created
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install PHP dependencies, optimized
-      run: composer install --no-dev -o
+      - name: Install PHP dependencies, optimized
+        run: composer install --no-dev -o
 
-    - name: Install JS dependencies
-      run: yarn
+      - name: Install JS dependencies
+        run: yarn
 
-    - name: Build assets for release
-      run: yarn build
-    # MUST set in package.json to same as tag name before pushing tag
-    - name: Set version number 
-      run: yarn version:number
-    - name: Create build
-      run: yarn package
-    - name: Create ZIP
+      - name: Build assets for release
+        run: yarn build
+
+      # MUST set in package.json to same as tag name before pushing tag
+      - name: Set version number 
+        run: yarn version:number
+
+      - name: Create build
+        run: yarn package
+
+      - name: Create ZIP
         uses: papeloto/action-zip@v1
         with:
           files: assets/ cf2/ classes/ fields/ languages/ vendor/ processors/ sendwp/ ui/ caldera-core.php readme.txt LICENSE
           recursive: false
           dest: caldera-forms-${{ github.ref }}.zip
-    - name: Upload ZIP to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: caldera-forms-${{ github.ref }}.zip
-        tag: ${{ github.ref }}
+
+      - name: Upload ZIP to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: caldera-forms-${{ github.ref }}.zip
+          tag: ${{ github.ref }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - "*"
-  release:
-    types:
-      - created
 
 jobs:
   build:
@@ -33,8 +30,8 @@ jobs:
       - name: Create ZIP
         uses: papeloto/action-zip@v1
         with:
-          files: assets/ cf2/ classes/ fields/ languages/ vendor/ processors/ sendwp/ ui/ caldera-core.php readme.txt LICENSE
-          recursive: false
+          files: build/${{ github.ref }}/
+          recursive: true
           dest: caldera-forms-${{ github.ref }}.zip
 
       - name: Upload ZIP to release

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,7 +279,7 @@ module.exports = function (grunt) {
                     mode:true
                 },
                 src:  files_list,
-                dest: 'build/<%= pkg.version %>',
+                dest: 'build/refs/tags/<%= pkg.version %>',
             }
         },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "caldera-forms",
-	"version": "1.9.1",
+	"version": "1.9.2-zipTest",
 	"description": "Apex WordPress Forms",
 	"main": "Gruntfile.js",
 	"repository": {


### PR DESCRIPTION
#3590

## What has changed
Added a new workflow that when a tag is added or release is added, a ZIP file is generated and then added to the release page.

## How To Test
Not sure, I would have thaught I needed to do these two things:

- Add a tag
- Add a release on this branch.

Then test that the ZIP is uploaded correctly and has all of the files we need, but I can't trigger the action either way. Maybe it needs to be in develop first?