### PR TITLE
[WIP] Removing SendGrid UI

### DIFF
--- a/classes/email/settings.php
+++ b/classes/email/settings.php
@@ -31,9 +31,9 @@ class Caldera_Forms_Email_Settings {
 
 	/**
 	 * Nonce action for settings UI
-	 * 
+	 *
 	 * @since 1.4.0
-	 * 
+	 *
 	 * @var string
 	 */
 	protected static $nonce_action = 'cf-emails';
@@ -50,7 +50,7 @@ class Caldera_Forms_Email_Settings {
 			'key' => false
 		),
 		'wp' => array(
-		
+
 		),
 		'method' => 'wp'
 	);
@@ -67,8 +67,8 @@ class Caldera_Forms_Email_Settings {
 			self::$settings = get_option( self::$option_key, array() );
 			self::$settings = wp_parse_args( self::$settings, self::$defaults );
 		}
-
-		return self::$settings;
+		
+		return apply_filters( 'change_email_settings', self::$settings, $arg1, $arg2 );
 	}
 
 	/**
@@ -114,9 +114,9 @@ class Caldera_Forms_Email_Settings {
 
 	/**
 	 * Check if is an allowed API
-	 * 
+	 *
 	 * @since 1.4.0
-	 * 
+	 *
 	 * @param string $api Name of API
 	 *
 	 * @return bool
@@ -128,16 +128,16 @@ class Caldera_Forms_Email_Settings {
 
 	/**
 	 * Save email settings
-	 * 
+	 *
 	 * @uses "wp_ajax_cf_email_save" action
-	 * 
+	 *
 	 * @since 1.3.5
 	 */
 	public static function save(){
 		if( ! current_user_can( Caldera_Forms::get_manage_cap( 'admin' ) ) ) {
 			wp_die();
 		}
-		
+
 		if( isset( $_POST[ 'nonce' ] ) && wp_verify_nonce( $_POST[ 'nonce' ], self::$nonce_action ) ){
 			if( isset( $_POST[ 'method' ] ) ){
 				if ( self::is_allowed_method( $_POST[ 'method' ] ) ) {
@@ -159,7 +159,7 @@ class Caldera_Forms_Email_Settings {
 		}
 
 		wp_send_json_error();
-		
+
 	}
 
 
@@ -186,7 +186,7 @@ class Caldera_Forms_Email_Settings {
 				}
 
 			}
-			
+
 		}
 
 
@@ -210,7 +210,7 @@ class Caldera_Forms_Email_Settings {
 	 * @since 1.4.0
 	 *
 	 * @param string $api API name
-	 
+
 	 * @return bool
 	 */
 	protected static function valid( $api ) {
@@ -261,7 +261,7 @@ class Caldera_Forms_Email_Settings {
 			include CFCORE_PATH . '/ui/emails/settings.php';
 
 		}
-		
+
 
 
 	}
@@ -306,7 +306,7 @@ class Caldera_Forms_Email_Settings {
 		if( ! is_array( $values ) ){
 			return self::$defaults;
 		}
-		
+
 		foreach ( $values as $key => $value ){
 			if( ! array_key_exists( $key, self::$defaults ) ){
 				unset( $values[ $key ] );
@@ -328,10 +328,10 @@ class Caldera_Forms_Email_Settings {
 				$values[ $api ] = self::$defaults[ $api ];
 			}
 		}
-		
-		
+
+
 		return $values;
-		
+
 	}
 
 }

--- a/ui/emails/settings.php
+++ b/ui/emails/settings.php
@@ -48,9 +48,6 @@
 				<option value="wp" <?php if ( 'wp'  == Caldera_Forms_Email_Settings::get_method() ) : echo 'selected'; endif; ?> >
 					<?php esc_html_e( 'WordPress', 'caldera-forms' ); ?>
 				</option>
-				<option value="sendgrid" <?php if ( 'sendgrid'  == Caldera_Forms_Email_Settings::get_method() ) : echo 'selected'; endif; ?> >
-					<?php esc_html_e( 'SendGrid', 'caldera-forms' ); ?>
-				</option>
 				<option value="caldera" <?php if ( 'caldera'  == Caldera_Forms_Email_Settings::get_method() ) : echo 'selected'; endif; ?> disabled >
 					<?php esc_html_e( 'Caldera (coming soon)', 'caldera-forms' ); ?>
 				</option>
@@ -59,23 +56,6 @@
 		<p class="description" id="cf-emails-api-desc" style="max-width: 440px; margin-bottom: 12px;">
 			<?php esc_html_e( 'By default Caldera Forms uses WordPress to send emails. You can choose to use another method to increase reliability of emails and reduce server load.', 'caldera-forms' ); ?>
 		</p>
-	</div>
-	<div class="cf-emails-field-group caldera-config-group" id="cf-emails-sendgrid-key-wrap">
-		<label for="cf-emails-sendgrid-key" id="cf-emails-sendgrid-key-label">
-			<?php esc_html_e( 'SendGrid API Key', 'caldera-forms' ); ?>
-		</label>
-		<div class="cf-emails-field-group">
-			<input type="text" class="cf-email-settings" id="cf-emails-sendgrid-key" name="cf-emails-sendgrid-key" value="<?php echo esc_attr( Caldera_Forms_Email_Settings::get_key( 'sendgrid' ) ); ?>">
-		</div>
-		<p class="description" id="cf-emails-sendgrid-key-desc" style="max-width: 440px; margin-bottom: 12px;">
-		<?php printf( '<span>%s</span> <span><a href="%s" target="_blank" rel="nofollow" title="%s">%s</a></span>',
-					esc_html__( 'SendGrid API Key', 'caldera-forms' ),
-					'https://CalderaWP.com/docs/configure-sendgrid',
-					esc_attr__( 'Documentation for configuring SendGrid API', 'caldera-forms' ),
-					esc_html__( 'Learn More', 'caldera-forms' )
-				);
-		?></p>
-
 	</div>
 	<?php echo Caldera_Forms_Email_Settings::nonce_field(); ?>
 	<br><br>


### PR DESCRIPTION
Removes SendGrid UI and add a hook to control the SendGrid email settings.

Fixes #3614

## What has changed?
- Removed SendGrid UI
- Added a filter change_email_settings

## How to test?
1. Check Email settings
1. No visual representation of SendGrid
1. Hook into filter
1. Use xdebug to see if data is being overwritten correctly