### PR TITLE
Allow other plugins to set a default for multi value checkboxes

### DIFF
--- a/classes/field/util.php
+++ b/classes/field/util.php
@@ -611,7 +611,7 @@ class Caldera_Forms_Field_Util {
 				$field_value = $option_values[ $field_value ];
 			}
 
-			if ( ! in_array( $field_value, $option_values ) ) {
+			if ( ! is_array($field_value) &&  ! in_array( $field_value, $option_values ) ) {
 				$field_value = null;
 			}
 


### PR DESCRIPTION
**Before**

If another plugin such as (Caldera CiviCRM Form Processor)[https://github.com/CiviMRF/cf-civicrm-formprocessor/] would set a default value for a multi checkbox, the default could only be one single value. Thus allowing checking only one of the checkboxes and not multiple at the same time.

**After**

If another plugin such as (Caldera CiviCRM Form Processor)[https://github.com/CiviMRF/cf-civicrm-formprocessor/] would set a default value for a multi checkbox, the default could be an array and thus multiple checkboxes would be checked.

**Why is this needed?**

We use calder forms for an update your profile allowing a user to update their first name, last name, email address and the list of subscribed email newsletters. The current information is retrieved from CiviCRM. For the newsletter we created a checkbox field and options for each newsletter. A user could be subscribed to multiple newsletters at the same time. (You can see the form at https://staging.civicoop.org/testpagina-inschrijven-nieuwsbrie)