### PR TITLE
WIP: jQuery migrate warnings

### DIFF
--- a/assets/js/caldera-forms-front.js
+++ b/assets/js/caldera-forms-front.js
@@ -1417,7 +1417,7 @@ function CFState(formId, $ ){
                     masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
                     masksetDefinition;
             }
-            if (typeof opts.mask === "function" && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
+            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), $.isArray(opts.mask)) {
                 if (opts.mask.length > 1) {
                     if (null === opts.keepStatic) {
                         opts.keepStatic = "auto";
@@ -1429,12 +1429,12 @@ function CFState(formId, $ ){
                     var altMask = opts.groupmarker[0];
                     return $.each(opts.isRTL ? opts.mask.reverse() : opts.mask, function(ndx, msk) {
                         altMask.length > 1 && (altMask += opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]),
-                            msk.mask === undefined || typeof msk.mask === "function" ? altMask += msk : altMask += msk.mask;
+                            msk.mask === undefined || $.isFunction(msk.mask) ? altMask += msk : altMask += msk.mask;
                     }), generateMask(altMask += opts.groupmarker[1], opts.mask, opts);
                 }
                 opts.mask = opts.mask.pop();
             }
-            return opts.mask && opts.mask.mask !== undefined && !typeof opts.mask.mask === "function" ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
+            return opts.mask && opts.mask.mask !== undefined && !$.isFunction(opts.mask.mask) ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
         }
         function isInputEventSupported(eventName) {
             var el = document.createElement("input"), evName = "on" + eventName, isSupported = evName in el;
@@ -1653,7 +1653,7 @@ function CFState(formId, $ ){
                         for (var test, previousPos = pos - 1; (test = getMaskSet().validPositions[previousPos] || getMaskSet().tests[previousPos]) === undefined && previousPos > -1; ) previousPos--;
                         test !== undefined && previousPos > -1 && (ndxInitializer = function(pos, tests) {
                             var locator = [];
-                            return tests.isArray() || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
+                            return $.isArray(tests) || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
                                 if ("" !== tst.def) if (0 === locator.length) locator = tst.locator.slice(); else for (var i = 0; i < locator.length; i++) tst.locator[i] && -1 === locator[i].toString().indexOf(tst.locator[i]) && (locator[i] += "," + tst.locator[i]);
                             })), locator;
                         }(previousPos, test), cacheDependency = ndxInitializer.join(""), testPos = previousPos);
@@ -1789,7 +1789,7 @@ function CFState(formId, $ ){
                                                 break;
 
                                             default:
-                                                if (typeof opts.casing === "function") {
+                                                if ($.isFunction(opts.casing)) {
                                                     var args = Array.prototype.slice.call(arguments);
                                                     args.push(getMaskSet().validPositions), elem = opts.casing.apply(this, args);
                                                 }
@@ -1802,7 +1802,7 @@ function CFState(formId, $ ){
                 }
                 pos.begin !== undefined && (maskPos = isRTL ? pos.end : pos.begin);
                 var result = !0, positionsClone = $.extend(!0, {}, getMaskSet().validPositions);
-                if (typeof opts.preValidation === "function" && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
+                if ($.isFunction(opts.preValidation) && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
                 !0 === result) {
                     if (trackbackPositions(undefined, maskPos, !0), (maxLength === undefined || maskPos < maxLength) && (result = _isValid(maskPos, c, strict),
                     (!strict || !0 === fromSetValid) && !1 === result && !0 !== validateOnly)) {
@@ -1822,7 +1822,7 @@ function CFState(formId, $ ){
                         pos: maskPos
                     });
                 }
-                if (typeof opts.postValidation === "function" && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
+                if ($.isFunction(opts.postValidation) && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
                     var postResult = opts.postValidation(getBuffer(!0), result, opts);
                     if (postResult !== undefined) {
                         if (postResult.refreshFromBuffer && postResult.buffer) {
@@ -1921,7 +1921,7 @@ function CFState(formId, $ ){
                 return position;
             }
             function writeBuffer(input, buffer, caretPos, event, triggerEvents) {
-                if (event && typeof opts.onBeforeWrite === "function") {
+                if (event && $.isFunction(opts.onBeforeWrite)) {
                     var result = opts.onBeforeWrite.call(inputmask, event, buffer, caretPos, opts);
                     if (result) {
                         if (result.refreshFromBuffer) {
@@ -1941,7 +1941,7 @@ function CFState(formId, $ ){
                 }
             }
             function getPlaceholder(pos, test, returnPL) {
-                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return typeof test.placeholder === "function" ? test.placeholder(opts) : test.placeholder;
+                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return $.isFunction(test.placeholder) ? test.placeholder(opts) : test.placeholder;
                 if (null === test.fn) {
                     if (pos > -1 && getMaskSet().validPositions[pos] === undefined) {
                         var prevTest, tests = getTests(pos), staticAlternations = [];
@@ -2074,7 +2074,7 @@ function CFState(formId, $ ){
                         inputValue = valueBeforeCaret + ev.clipboardData.getData("text/plain") + valueAfterCaret;
                     }
                     var pasteValue = inputValue;
-                    if (typeof opts.onBeforePaste === "function") {
+                    if ($.isFunction(opts.onBeforePaste)) {
                         if (!1 === (pasteValue = opts.onBeforePaste.call(inputmask, inputValue, opts))) return e.preventDefault();
                         pasteValue || (pasteValue = inputValue);
                     }
@@ -2146,7 +2146,7 @@ function CFState(formId, $ ){
                 setValueEvent: function(e) {
                     this.inputmask.refreshValue = !1;
                     var value = (value = e && e.detail ? e.detail[0] : arguments[1]) || this.inputmask._valueGet(!0);
-                    typeof opts.onBeforeMask === "function" && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
+                    $.isFunction(opts.onBeforeMask) && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
                         checkVal(this, !0, !1, value = value.split("")), undoValue = getBuffer().join(""),
                     (opts.clearMaskOnLostFocus || opts.clearIncomplete) && this.inputmask._valueGet() === getBufferTemplate().join("") && this.inputmask._valueSet("");
                 },
@@ -2292,7 +2292,7 @@ function CFState(formId, $ ){
                 var umValue = [], vps = getMaskSet().validPositions;
                 for (var pndx in vps) vps[pndx].match && null != vps[pndx].match.fn && umValue.push(vps[pndx].input);
                 var unmaskedValue = 0 === umValue.length ? "" : (isRTL ? umValue.reverse() : umValue).join("");
-                if (typeof opts.onUnMask === "function") {
+                if ($.isFunction(opts.onUnMask)) {
                     var bufferValue = (isRTL ? getBuffer().slice().reverse() : getBuffer()).join("");
                     unmaskedValue = opts.onUnMask.call(inputmask, bufferValue, unmaskedValue, opts);
                 }
@@ -2355,7 +2355,7 @@ function CFState(formId, $ ){
                 return buffer;
             }
             function isComplete(buffer) {
-                if (typeof opts.isComplete === "function") return opts.isComplete(buffer, opts);
+                if ($.isFunction(opts.isComplete)) return opts.isComplete(buffer, opts);
                 if ("*" === opts.repeat) return undefined;
                 var complete = !1, lrp = determineLastRequiredPosition(!0), aml = seekPrevious(lrp.l);
                 if (lrp.def === undefined || lrp.def.newBlockMarker || lrp.def.optionality || lrp.def.optionalQuantifier) {
@@ -2463,8 +2463,8 @@ function CFState(formId, $ ){
 
                 case "unmaskedvalue":
                     return el !== undefined && actionObj.value === undefined || (valueBuffer = actionObj.value,
-                        valueBuffer = (typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
-                        checkVal.call(this, undefined, !1, !1, valueBuffer), typeof opts.onBeforeWrite === "function" && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
+                        valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
+                        checkVal.call(this, undefined, !1, !1, valueBuffer), $.isFunction(opts.onBeforeWrite) && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
                         unmaskedvalue(el);
 
                 case "mask":
@@ -2570,7 +2570,7 @@ function CFState(formId, $ ){
                             EventRuler.on(el, "keyup", $.noop), EventRuler.on(el, "input", EventHandlers.inputFallBackEvent),
                             EventRuler.on(el, "beforeinput", EventHandlers.beforeInputEvent)), EventRuler.on(el, "setvalue", EventHandlers.setValueEvent),
                             undoValue = getBufferTemplate().join(""), "" !== el.inputmask._valueGet(!0) || !1 === opts.clearMaskOnLostFocus || document.activeElement === el)) {
-                            var initialValue = typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
+                            var initialValue = $.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
                             "" !== initialValue && checkVal(el, !0, !1, initialValue.split(""));
                             var buffer = getBuffer().slice();
                             undoValue = buffer.join(""), !1 === isComplete(buffer) && opts.clearIncomplete && resetMaskSet(),
@@ -2582,7 +2582,7 @@ function CFState(formId, $ ){
                     break;
 
                 case "format":
-                    return valueBuffer = (typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
+                    return valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
                         checkVal.call(this, undefined, !0, !1, valueBuffer), actionObj.metadata ? {
                         value: isRTL ? getBuffer().slice().reverse().join("") : getBuffer().join(""),
                         metadata: maskScope.call(this, {
@@ -2645,7 +2645,7 @@ function CFState(formId, $ ){
                 onKeyDown: $.noop,
                 onBeforeMask: null,
                 onBeforePaste: function(pastedValue, opts) {
-                    return typeof opts.onBeforeMask === "function" ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
+                    return $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
                 },
                 onBeforeWrite: null,
                 onUnMask: null,
@@ -3640,7 +3640,7 @@ function CFState(formId, $ ){
             }((mask = mask.substr(1, mask.length - 2)).split(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0])),
                 mask = function rebuild(maskGroup) {
                     var mask = "", submasks = [];
-                    for (var ndx in maskGroup) maskGroup[ndx].isArray() ? 1 === maskGroup[ndx].length ? submasks.push(ndx + maskGroup[ndx]) : submasks.push(ndx + opts.groupmarker[0] + maskGroup[ndx].join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1]) : submasks.push(ndx + rebuild(maskGroup[ndx]));
+                    for (var ndx in maskGroup) $.isArray(maskGroup[ndx]) ? 1 === maskGroup[ndx].length ? submasks.push(ndx + maskGroup[ndx]) : submasks.push(ndx + opts.groupmarker[0] + maskGroup[ndx].join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1]) : submasks.push(ndx + rebuild(maskGroup[ndx]));
                     return 1 === submasks.length ? mask += submasks[0] : mask += opts.groupmarker[0] + submasks.join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1],
                         mask;
                 }(maskGroups)), mask = mask.replace(/9/g, "\\9")), analyseMaskBase.call(this, mask, regexMask, opts);
@@ -4234,14 +4234,14 @@ jQuery( document ).ajaxComplete(function() {
         },
 
         setDates: function(){
-            var args = arguments[0].isArray() ? arguments[0] : arguments;
+            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
             this.update.apply(this, args);
             this._trigger('changeDate');
             this.setValue();
         },
 
         setUTCDates: function(){
-            var args = arguments[0].isArray() ? arguments[0] : arguments;
+            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
             this.update.apply(this, $.map(args, this._utc_to_local));
             this._trigger('changeDate');
             this.setValue();

--- a/assets/js/caldera-forms-front.js
+++ b/assets/js/caldera-forms-front.js
@@ -1417,7 +1417,7 @@ function CFState(formId, $ ){
                     masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
                     masksetDefinition;
             }
-            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), $.isArray(opts.mask)) {
+            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
                 if (opts.mask.length > 1) {
                     if (null === opts.keepStatic) {
                         opts.keepStatic = "auto";
@@ -1653,7 +1653,7 @@ function CFState(formId, $ ){
                         for (var test, previousPos = pos - 1; (test = getMaskSet().validPositions[previousPos] || getMaskSet().tests[previousPos]) === undefined && previousPos > -1; ) previousPos--;
                         test !== undefined && previousPos > -1 && (ndxInitializer = function(pos, tests) {
                             var locator = [];
-                            return $.isArray(tests) || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
+                            return tests.isArray() || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
                                 if ("" !== tst.def) if (0 === locator.length) locator = tst.locator.slice(); else for (var i = 0; i < locator.length; i++) tst.locator[i] && -1 === locator[i].toString().indexOf(tst.locator[i]) && (locator[i] += "," + tst.locator[i]);
                             })), locator;
                         }(previousPos, test), cacheDependency = ndxInitializer.join(""), testPos = previousPos);
@@ -3640,7 +3640,7 @@ function CFState(formId, $ ){
             }((mask = mask.substr(1, mask.length - 2)).split(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0])),
                 mask = function rebuild(maskGroup) {
                     var mask = "", submasks = [];
-                    for (var ndx in maskGroup) $.isArray(maskGroup[ndx]) ? 1 === maskGroup[ndx].length ? submasks.push(ndx + maskGroup[ndx]) : submasks.push(ndx + opts.groupmarker[0] + maskGroup[ndx].join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1]) : submasks.push(ndx + rebuild(maskGroup[ndx]));
+                    for (var ndx in maskGroup) maskGroup[ndx].isArray() ? 1 === maskGroup[ndx].length ? submasks.push(ndx + maskGroup[ndx]) : submasks.push(ndx + opts.groupmarker[0] + maskGroup[ndx].join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1]) : submasks.push(ndx + rebuild(maskGroup[ndx]));
                     return 1 === submasks.length ? mask += submasks[0] : mask += opts.groupmarker[0] + submasks.join(opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]) + opts.groupmarker[1],
                         mask;
                 }(maskGroups)), mask = mask.replace(/9/g, "\\9")), analyseMaskBase.call(this, mask, regexMask, opts);
@@ -4234,14 +4234,14 @@ jQuery( document ).ajaxComplete(function() {
         },
 
         setDates: function(){
-            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+            var args = arguments[0].isArray() ? arguments[0] : arguments;
             this.update.apply(this, args);
             this._trigger('changeDate');
             this.setValue();
         },
 
         setUTCDates: function(){
-            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+            var args = arguments[0].isArray() ? arguments[0] : arguments;
             this.update.apply(this, $.map(args, this._utc_to_local));
             this._trigger('changeDate');
             this.setValue();

--- a/assets/js/caldera-forms-front.js
+++ b/assets/js/caldera-forms-front.js
@@ -1417,7 +1417,7 @@ function CFState(formId, $ ){
                     masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
                     masksetDefinition;
             }
-            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
+            if (typeof opts.mask === "function" && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
                 if (opts.mask.length > 1) {
                     if (null === opts.keepStatic) {
                         opts.keepStatic = "auto";
@@ -1429,12 +1429,12 @@ function CFState(formId, $ ){
                     var altMask = opts.groupmarker[0];
                     return $.each(opts.isRTL ? opts.mask.reverse() : opts.mask, function(ndx, msk) {
                         altMask.length > 1 && (altMask += opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]),
-                            msk.mask === undefined || $.isFunction(msk.mask) ? altMask += msk : altMask += msk.mask;
+                            msk.mask === undefined || typeof msk.mask === "function" ? altMask += msk : altMask += msk.mask;
                     }), generateMask(altMask += opts.groupmarker[1], opts.mask, opts);
                 }
                 opts.mask = opts.mask.pop();
             }
-            return opts.mask && opts.mask.mask !== undefined && !$.isFunction(opts.mask.mask) ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
+            return opts.mask && opts.mask.mask !== undefined && !typeof opts.mask.mask === "function" ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
         }
         function isInputEventSupported(eventName) {
             var el = document.createElement("input"), evName = "on" + eventName, isSupported = evName in el;
@@ -1789,7 +1789,7 @@ function CFState(formId, $ ){
                                                 break;
 
                                             default:
-                                                if ($.isFunction(opts.casing)) {
+                                                if (typeof opts.casing === "function") {
                                                     var args = Array.prototype.slice.call(arguments);
                                                     args.push(getMaskSet().validPositions), elem = opts.casing.apply(this, args);
                                                 }
@@ -1802,7 +1802,7 @@ function CFState(formId, $ ){
                 }
                 pos.begin !== undefined && (maskPos = isRTL ? pos.end : pos.begin);
                 var result = !0, positionsClone = $.extend(!0, {}, getMaskSet().validPositions);
-                if ($.isFunction(opts.preValidation) && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
+                if (typeof opts.preValidation === "function" && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
                 !0 === result) {
                     if (trackbackPositions(undefined, maskPos, !0), (maxLength === undefined || maskPos < maxLength) && (result = _isValid(maskPos, c, strict),
                     (!strict || !0 === fromSetValid) && !1 === result && !0 !== validateOnly)) {
@@ -1822,7 +1822,7 @@ function CFState(formId, $ ){
                         pos: maskPos
                     });
                 }
-                if ($.isFunction(opts.postValidation) && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
+                if (typeof opts.postValidation === "function" && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
                     var postResult = opts.postValidation(getBuffer(!0), result, opts);
                     if (postResult !== undefined) {
                         if (postResult.refreshFromBuffer && postResult.buffer) {
@@ -1921,7 +1921,7 @@ function CFState(formId, $ ){
                 return position;
             }
             function writeBuffer(input, buffer, caretPos, event, triggerEvents) {
-                if (event && $.isFunction(opts.onBeforeWrite)) {
+                if (event && typeof opts.onBeforeWrite === "function") {
                     var result = opts.onBeforeWrite.call(inputmask, event, buffer, caretPos, opts);
                     if (result) {
                         if (result.refreshFromBuffer) {
@@ -1941,7 +1941,7 @@ function CFState(formId, $ ){
                 }
             }
             function getPlaceholder(pos, test, returnPL) {
-                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return $.isFunction(test.placeholder) ? test.placeholder(opts) : test.placeholder;
+                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return typeof test.placeholder === "function" ? test.placeholder(opts) : test.placeholder;
                 if (null === test.fn) {
                     if (pos > -1 && getMaskSet().validPositions[pos] === undefined) {
                         var prevTest, tests = getTests(pos), staticAlternations = [];
@@ -2074,7 +2074,7 @@ function CFState(formId, $ ){
                         inputValue = valueBeforeCaret + ev.clipboardData.getData("text/plain") + valueAfterCaret;
                     }
                     var pasteValue = inputValue;
-                    if ($.isFunction(opts.onBeforePaste)) {
+                    if (typeof opts.onBeforePaste === "function") {
                         if (!1 === (pasteValue = opts.onBeforePaste.call(inputmask, inputValue, opts))) return e.preventDefault();
                         pasteValue || (pasteValue = inputValue);
                     }
@@ -2146,7 +2146,7 @@ function CFState(formId, $ ){
                 setValueEvent: function(e) {
                     this.inputmask.refreshValue = !1;
                     var value = (value = e && e.detail ? e.detail[0] : arguments[1]) || this.inputmask._valueGet(!0);
-                    $.isFunction(opts.onBeforeMask) && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
+                    typeof opts.onBeforeMask === "function" && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
                         checkVal(this, !0, !1, value = value.split("")), undoValue = getBuffer().join(""),
                     (opts.clearMaskOnLostFocus || opts.clearIncomplete) && this.inputmask._valueGet() === getBufferTemplate().join("") && this.inputmask._valueSet("");
                 },
@@ -2292,7 +2292,7 @@ function CFState(formId, $ ){
                 var umValue = [], vps = getMaskSet().validPositions;
                 for (var pndx in vps) vps[pndx].match && null != vps[pndx].match.fn && umValue.push(vps[pndx].input);
                 var unmaskedValue = 0 === umValue.length ? "" : (isRTL ? umValue.reverse() : umValue).join("");
-                if ($.isFunction(opts.onUnMask)) {
+                if (typeof opts.onUnMask === "function") {
                     var bufferValue = (isRTL ? getBuffer().slice().reverse() : getBuffer()).join("");
                     unmaskedValue = opts.onUnMask.call(inputmask, bufferValue, unmaskedValue, opts);
                 }
@@ -2355,7 +2355,7 @@ function CFState(formId, $ ){
                 return buffer;
             }
             function isComplete(buffer) {
-                if ($.isFunction(opts.isComplete)) return opts.isComplete(buffer, opts);
+                if (typeof opts.isComplete === "function") return opts.isComplete(buffer, opts);
                 if ("*" === opts.repeat) return undefined;
                 var complete = !1, lrp = determineLastRequiredPosition(!0), aml = seekPrevious(lrp.l);
                 if (lrp.def === undefined || lrp.def.newBlockMarker || lrp.def.optionality || lrp.def.optionalQuantifier) {
@@ -2463,8 +2463,8 @@ function CFState(formId, $ ){
 
                 case "unmaskedvalue":
                     return el !== undefined && actionObj.value === undefined || (valueBuffer = actionObj.value,
-                        valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
-                        checkVal.call(this, undefined, !1, !1, valueBuffer), $.isFunction(opts.onBeforeWrite) && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
+                        valueBuffer = (typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
+                        checkVal.call(this, undefined, !1, !1, valueBuffer), typeof opts.onBeforeWrite === "function" && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
                         unmaskedvalue(el);
 
                 case "mask":
@@ -2570,7 +2570,7 @@ function CFState(formId, $ ){
                             EventRuler.on(el, "keyup", $.noop), EventRuler.on(el, "input", EventHandlers.inputFallBackEvent),
                             EventRuler.on(el, "beforeinput", EventHandlers.beforeInputEvent)), EventRuler.on(el, "setvalue", EventHandlers.setValueEvent),
                             undoValue = getBufferTemplate().join(""), "" !== el.inputmask._valueGet(!0) || !1 === opts.clearMaskOnLostFocus || document.activeElement === el)) {
-                            var initialValue = $.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
+                            var initialValue = typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
                             "" !== initialValue && checkVal(el, !0, !1, initialValue.split(""));
                             var buffer = getBuffer().slice();
                             undoValue = buffer.join(""), !1 === isComplete(buffer) && opts.clearIncomplete && resetMaskSet(),
@@ -2582,7 +2582,7 @@ function CFState(formId, $ ){
                     break;
 
                 case "format":
-                    return valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
+                    return valueBuffer = (typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
                         checkVal.call(this, undefined, !0, !1, valueBuffer), actionObj.metadata ? {
                         value: isRTL ? getBuffer().slice().reverse().join("") : getBuffer().join(""),
                         metadata: maskScope.call(this, {
@@ -2645,7 +2645,7 @@ function CFState(formId, $ ){
                 onKeyDown: $.noop,
                 onBeforeMask: null,
                 onBeforePaste: function(pastedValue, opts) {
-                    return $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
+                    return typeof opts.onBeforeMask === "function" ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
                 },
                 onBeforeWrite: null,
                 onUnMask: null,

--- a/assets/js/inputmask.js
+++ b/assets/js/inputmask.js
@@ -88,7 +88,7 @@
                     masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
                     masksetDefinition;
             }
-            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
+            if (typeof opts.mask ==="function" && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
                 if (opts.mask.length > 1) {
                     if (null === opts.keepStatic) {
                         opts.keepStatic = "auto";
@@ -100,12 +100,12 @@
                     var altMask = opts.groupmarker[0];
                     return $.each(opts.isRTL ? opts.mask.reverse() : opts.mask, function(ndx, msk) {
                         altMask.length > 1 && (altMask += opts.groupmarker[1] + opts.alternatormarker + opts.groupmarker[0]),
-                            msk.mask === undefined || $.isFunction(msk.mask) ? altMask += msk : altMask += msk.mask;
+                            msk.mask === undefined || typeof msk.mask === "function" ? altMask += msk : altMask += msk.mask;
                     }), generateMask(altMask += opts.groupmarker[1], opts.mask, opts);
                 }
                 opts.mask = opts.mask.pop();
             }
-            return opts.mask && opts.mask.mask !== undefined && !$.isFunction(opts.mask.mask) ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
+            return opts.mask && opts.mask.mask !== undefined && !typeof opts.mask.mask === "function" ? generateMask(opts.mask.mask, opts.mask, opts) : generateMask(opts.mask, opts.mask, opts);
         }
         function isInputEventSupported(eventName) {
             var el = document.createElement("input"), evName = "on" + eventName, isSupported = evName in el;
@@ -460,7 +460,7 @@
                                                 break;
 
                                             default:
-                                                if ($.isFunction(opts.casing)) {
+                                                if (typeof opts.casing === "function") {
                                                     var args = Array.prototype.slice.call(arguments);
                                                     args.push(getMaskSet().validPositions), elem = opts.casing.apply(this, args);
                                                 }
@@ -473,7 +473,7 @@
                 }
                 pos.begin !== undefined && (maskPos = isRTL ? pos.end : pos.begin);
                 var result = !0, positionsClone = $.extend(!0, {}, getMaskSet().validPositions);
-                if ($.isFunction(opts.preValidation) && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
+                if (typeof opts.preValidation === "function" && !strict && !0 !== fromSetValid && !0 !== validateOnly && (result = opts.preValidation(getBuffer(), maskPos, c, isSelection(pos), opts, getMaskSet())),
                 !0 === result) {
                     if (trackbackPositions(undefined, maskPos, !0), (maxLength === undefined || maskPos < maxLength) && (result = _isValid(maskPos, c, strict),
                     (!strict || !0 === fromSetValid) && !1 === result && !0 !== validateOnly)) {
@@ -493,7 +493,7 @@
                         pos: maskPos
                     });
                 }
-                if ($.isFunction(opts.postValidation) && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
+                if (typeof opts.postValidation === "function" && !1 !== result && !strict && !0 !== fromSetValid && !0 !== validateOnly) {
                     var postResult = opts.postValidation(getBuffer(!0), result, opts);
                     if (postResult !== undefined) {
                         if (postResult.refreshFromBuffer && postResult.buffer) {
@@ -592,7 +592,7 @@
                 return position;
             }
             function writeBuffer(input, buffer, caretPos, event, triggerEvents) {
-                if (event && $.isFunction(opts.onBeforeWrite)) {
+                if (event && typeof opts.onBeforeWrite ==="function") {
                     var result = opts.onBeforeWrite.call(inputmask, event, buffer, caretPos, opts);
                     if (result) {
                         if (result.refreshFromBuffer) {
@@ -612,7 +612,7 @@
                 }
             }
             function getPlaceholder(pos, test, returnPL) {
-                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return $.isFunction(test.placeholder) ? test.placeholder(opts) : test.placeholder;
+                if ((test = test || getTest(pos).match).placeholder !== undefined || !0 === returnPL) return typeof test.placeholder === "function" ? test.placeholder(opts) : test.placeholder;
                 if (null === test.fn) {
                     if (pos > -1 && getMaskSet().validPositions[pos] === undefined) {
                         var prevTest, tests = getTests(pos), staticAlternations = [];
@@ -745,7 +745,7 @@
                         inputValue = valueBeforeCaret + ev.clipboardData.getData("text/plain") + valueAfterCaret;
                     }
                     var pasteValue = inputValue;
-                    if ($.isFunction(opts.onBeforePaste)) {
+                    if (typeof opts.onBeforePaste === "function") {
                         if (!1 === (pasteValue = opts.onBeforePaste.call(inputmask, inputValue, opts))) return e.preventDefault();
                         pasteValue || (pasteValue = inputValue);
                     }
@@ -817,7 +817,7 @@
                 setValueEvent: function(e) {
                     this.inputmask.refreshValue = !1;
                     var value = (value = e && e.detail ? e.detail[0] : arguments[1]) || this.inputmask._valueGet(!0);
-                    $.isFunction(opts.onBeforeMask) && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
+                    typeof opts.onBeforeMask === "function" && (value = opts.onBeforeMask.call(inputmask, value, opts) || value),
                         checkVal(this, !0, !1, value = value.split("")), undoValue = getBuffer().join(""),
                     (opts.clearMaskOnLostFocus || opts.clearIncomplete) && this.inputmask._valueGet() === getBufferTemplate().join("") && this.inputmask._valueSet("");
                 },
@@ -963,7 +963,7 @@
                 var umValue = [], vps = getMaskSet().validPositions;
                 for (var pndx in vps) vps[pndx].match && null != vps[pndx].match.fn && umValue.push(vps[pndx].input);
                 var unmaskedValue = 0 === umValue.length ? "" : (isRTL ? umValue.reverse() : umValue).join("");
-                if ($.isFunction(opts.onUnMask)) {
+                if (typeof opts.onUnMask === "function") {
                     var bufferValue = (isRTL ? getBuffer().slice().reverse() : getBuffer()).join("");
                     unmaskedValue = opts.onUnMask.call(inputmask, bufferValue, unmaskedValue, opts);
                 }
@@ -1026,7 +1026,7 @@
                 return buffer;
             }
             function isComplete(buffer) {
-                if ($.isFunction(opts.isComplete)) return opts.isComplete(buffer, opts);
+                if (typeof opts.isComplete === "function") return opts.isComplete(buffer, opts);
                 if ("*" === opts.repeat) return undefined;
                 var complete = !1, lrp = determineLastRequiredPosition(!0), aml = seekPrevious(lrp.l);
                 if (lrp.def === undefined || lrp.def.newBlockMarker || lrp.def.optionality || lrp.def.optionalQuantifier) {
@@ -1134,8 +1134,8 @@
 
                 case "unmaskedvalue":
                     return el !== undefined && actionObj.value === undefined || (valueBuffer = actionObj.value,
-                        valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
-                        checkVal.call(this, undefined, !1, !1, valueBuffer), $.isFunction(opts.onBeforeWrite) && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
+                        valueBuffer = (typeof opts.onBeforeMask ==="function" && opts.onBeforeMask.call(inputmask, valueBuffer, opts) || valueBuffer).split(""),
+                        checkVal.call(this, undefined, !1, !1, valueBuffer), typeof opts.onBeforeWrite ==="function" && opts.onBeforeWrite.call(inputmask, undefined, getBuffer(), 0, opts)),
                         unmaskedvalue(el);
 
                 case "mask":
@@ -1241,7 +1241,7 @@
                             EventRuler.on(el, "keyup", $.noop), EventRuler.on(el, "input", EventHandlers.inputFallBackEvent),
                             EventRuler.on(el, "beforeinput", EventHandlers.beforeInputEvent)), EventRuler.on(el, "setvalue", EventHandlers.setValueEvent),
                             undoValue = getBufferTemplate().join(""), "" !== el.inputmask._valueGet(!0) || !1 === opts.clearMaskOnLostFocus || document.activeElement === el)) {
-                            var initialValue = $.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
+                            var initialValue = typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, el.inputmask._valueGet(!0), opts) || el.inputmask._valueGet(!0);
                             "" !== initialValue && checkVal(el, !0, !1, initialValue.split(""));
                             var buffer = getBuffer().slice();
                             undoValue = buffer.join(""), !1 === isComplete(buffer) && opts.clearIncomplete && resetMaskSet(),
@@ -1253,7 +1253,7 @@
                     break;
 
                 case "format":
-                    return valueBuffer = ($.isFunction(opts.onBeforeMask) && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
+                    return valueBuffer = (typeof opts.onBeforeMask === "function" && opts.onBeforeMask.call(inputmask, actionObj.value, opts) || actionObj.value).split(""),
                         checkVal.call(this, undefined, !0, !1, valueBuffer), actionObj.metadata ? {
                         value: isRTL ? getBuffer().slice().reverse().join("") : getBuffer().join(""),
                         metadata: maskScope.call(this, {
@@ -1316,7 +1316,7 @@
                 onKeyDown: $.noop,
                 onBeforeMask: null,
                 onBeforePaste: function(pastedValue, opts) {
-                    return $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
+                    return typeof opts.onBeforeMask === "function" ? opts.onBeforeMask.call(this, pastedValue, opts) : pastedValue;
                 },
                 onBeforeWrite: null,
                 onUnMask: null,

--- a/assets/js/inputmask.js
+++ b/assets/js/inputmask.js
@@ -88,7 +88,7 @@
                     masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]))) : masksetDefinition = $.extend(!0, {}, Inputmask.prototype.masksCache[maskdefKey]),
                     masksetDefinition;
             }
-            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), $.isArray(opts.mask)) {
+            if ($.isFunction(opts.mask) && (opts.mask = opts.mask(opts)), opts.mask.isArray()) {
                 if (opts.mask.length > 1) {
                     if (null === opts.keepStatic) {
                         opts.keepStatic = "auto";
@@ -324,7 +324,7 @@
                         for (var test, previousPos = pos - 1; (test = getMaskSet().validPositions[previousPos] || getMaskSet().tests[previousPos]) === undefined && previousPos > -1; ) previousPos--;
                         test !== undefined && previousPos > -1 && (ndxInitializer = function(pos, tests) {
                             var locator = [];
-                            return $.isArray(tests) || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
+                            return tests.isArray() || (tests = [ tests ]), tests.length > 0 && (tests[0].alternation === undefined ? 0 === (locator = determineTestTemplate(pos, tests.slice()).locator.slice()).length && (locator = tests[0].locator.slice()) : $.each(tests, function(ndx, tst) {
                                 if ("" !== tst.def) if (0 === locator.length) locator = tst.locator.slice(); else for (var i = 0; i < locator.length; i++) tst.locator[i] && -1 === locator[i].toString().indexOf(tst.locator[i]) && (locator[i] += "," + tst.locator[i]);
                             })), locator;
                         }(previousPos, test), cacheDependency = ndxInitializer.join(""), testPos = previousPos);

--- a/fields/date_picker/cf-datepicker.js
+++ b/fields/date_picker/cf-datepicker.js
@@ -481,14 +481,14 @@
         },
 
         setDates: function(){
-            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+            var args = arguments[0].isArray() ? arguments[0] : arguments;
             this.update.apply(this, args);
             this._trigger('changeDate');
             this.setValue();
         },
 
         setUTCDates: function(){
-            var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+            var args = arguments[0].isArray() ? arguments[0] : arguments;
             this.update.apply(this, $.map(args, this._utc_to_local));
             this._trigger('changeDate');
             this.setValue();

--- a/fields/date_picker/js/bootstrap-datepicker.js
+++ b/fields/date_picker/js/bootstrap-datepicker.js
@@ -481,14 +481,14 @@
 		},
 
 		setDates: function(){
-			var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+			var args = arguments[0].isArray() ? arguments[0] : arguments;
 			this.update.apply(this, args);
 			this._trigger('changeDate');
 			this.setValue();
 		},
 
 		setUTCDates: function(){
-			var args = $.isArray(arguments[0]) ? arguments[0] : arguments;
+			var args = arguments[0].isArray() ? arguments[0] : arguments;
 			this.update.apply(this, $.map(args, this._utc_to_local));
 			this._trigger('changeDate');
 			this.setValue();

--- a/fields/phone/masked-input.js
+++ b/fields/phone/masked-input.js
@@ -175,16 +175,16 @@
             }), $.extend(!0, {}, $.inputmask.masksCache[mask]);
         }
         var ms = void 0;
-        if ($.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray()) if (multi) ms = [], 
+        if (typeof opts.mask === "function" && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray()) if (multi) ms = [], 
         $.each(opts.mask, function(ndx, msk) {
-            ms.push(void 0 == msk.mask || $.isFunction(msk.mask) ? generateMask(msk.toString(), msk) : generateMask(msk.mask.toString(), msk));
+            ms.push(void 0 == msk.mask || typeof msk.mask === "function" ? generateMask(msk.toString(), msk) : generateMask(msk.mask.toString(), msk));
         }); else {
             opts.keepStatic = void 0 == opts.keepStatic ? !0 : opts.keepStatic;
             var altMask = "(";
             $.each(opts.mask, function(ndx, msk) {
-                altMask.length > 1 && (altMask += ")|("), altMask += void 0 == msk.mask || $.isFunction(msk.mask) ? msk.toString() : msk.mask.toString();
+                altMask.length > 1 && (altMask += ")|("), altMask += void 0 == msk.mask || typeof msk.mask === "function" ? msk.toString() : msk.mask.toString();
             }), altMask += ")", ms = generateMask(altMask, opts.mask);
-        } else opts.mask && (ms = void 0 == opts.mask.mask || $.isFunction(opts.mask.mask) ? generateMask(opts.mask.toString(), opts.mask) : generateMask(opts.mask.mask.toString(), opts.mask));
+        } else opts.mask && (ms = void 0 == opts.mask.mask || typeof opts.mask.mask === "function" ? generateMask(opts.mask.toString(), opts.mask) : generateMask(opts.mask.mask.toString(), opts.mask));
         return ms;
     }
     function maskScope(actionObj, maskset, opts) {
@@ -519,7 +519,7 @@
         }
         function getPlaceholder(pos, test) {
             test = test || getTest(pos);
-            var placeholder = $.isFunction(test.placeholder) ? test.placeholder.call(this, opts) : test.placeholder;
+            var placeholder = typeof test.placeholder === "function" ? test.placeholder.call(this, opts) : test.placeholder;
             return void 0 != placeholder ? placeholder : null == test.fn ? test.def : opts.placeholder.charAt(pos % opts.placeholder.length);
         }
         function checkVal(input, writeOut, strict, nptvl, intelliCheck) {
@@ -546,7 +546,7 @@
                 var umValue = [], vps = getMaskSet().validPositions;
                 for (var pndx in vps) vps[pndx].match && null != vps[pndx].match.fn && umValue.push(vps[pndx].input);
                 var unmaskedValue = (isRTL ? umValue.reverse() : umValue).join(""), bufferValue = (isRTL ? getBuffer().slice().reverse() : getBuffer()).join("");
-                return $.isFunction(opts.onUnMask) && (unmaskedValue = opts.onUnMask.call($input, bufferValue, unmaskedValue, opts) || unmaskedValue), 
+                return typeof opts.onUnMask === "function" && (unmaskedValue = opts.onUnMask.call($input, bufferValue, unmaskedValue, opts) || unmaskedValue), 
                 unmaskedValue;
             }
             return $input[0]._valueGet();
@@ -597,7 +597,7 @@
             tmpBuffer.splice(rl, lmib + 1 - rl), writeBuffer(input, tmpBuffer);
         }
         function isComplete(buffer) {
-            if ($.isFunction(opts.isComplete)) return opts.isComplete.call($el, buffer, opts);
+            if (typeof opts.isComplete === "function") return opts.isComplete.call($el, buffer, opts);
             if ("*" == opts.repeat) return void 0;
             var complete = !1, lrp = determineLastRequiredPosition(!0), aml = seekPrevious(lrp.l), lvp = getLastValidPosition();
             if (lvp == aml && (void 0 == lrp.def || lrp.def.newBlockMarker || lrp.def.optionalQuantifier)) {
@@ -648,7 +648,7 @@
                         },
                         set: function(elem, value) {
                             var result, $elem = $(elem), inputData = $elem.data("_inputmask");
-                            return inputData ? (result = valueSet(elem, $.isFunction(inputData.opts.onBeforeMask) ? inputData.opts.onBeforeMask.call(el, value, inputData.opts) || value : value), 
+                            return inputData ? (result = valueSet(elem, typeof inputData.opts.onBeforeMask === "function" ? inputData.opts.onBeforeMask.call(el, value, inputData.opts) || value : value), 
                             $elem.triggerHandler("setvalue.inputmask")) : result = valueSet(elem, value), result;
                         },
                         inputmaskpatch: !0
@@ -661,7 +661,7 @@
             }
             function setter(value) {
                 var inputData = $(this).data("_inputmask");
-                inputData ? (valueSet.call(this, $.isFunction(inputData.opts.onBeforeMask) ? inputData.opts.onBeforeMask.call(el, value, inputData.opts) || value : value), 
+                inputData ? (valueSet.call(this, typeof inputData.opts.onBeforeMask === "function" ? inputData.opts.onBeforeMask.call(el, value, inputData.opts) || value : value), 
                 $(this).triggerHandler("setvalue.inputmask")) : valueSet.call(this, value);
             }
             function InstallNativeValueSetFallback(npt) {
@@ -799,7 +799,7 @@
             var input = this, $input = $(input), inputValue = input._valueGet(), caretPos = caret(input);
             if ("propertychange" == e.type && input._valueGet().length <= getMaskLength()) return !0;
             "paste" == e.type && (window.clipboardData && window.clipboardData.getData ? inputValue = inputValue.substr(0, caretPos.begin) + window.clipboardData.getData("Text") + inputValue.substr(caretPos.end, inputValue.length) : e.originalEvent && e.originalEvent.clipboardData && e.originalEvent.clipboardData.getData && (inputValue = inputValue.substr(0, caretPos.begin) + e.originalEvent.clipboardData.getData("text/plain") + inputValue.substr(caretPos.end, inputValue.length)));
-            var pasteValue = $.isFunction(opts.onBeforePaste) ? opts.onBeforePaste.call(input, inputValue, opts) || inputValue : inputValue;
+            var pasteValue = typeof opts.onBeforePaste === "function" ? opts.onBeforePaste.call(input, inputValue, opts) || inputValue : inputValue;
             return checkVal(input, !0, !1, isRTL ? pasteValue.split("").reverse() : pasteValue.split(""), !0), 
             $input.click(), isComplete(getBuffer()) === !0 && $input.trigger("complete"), !1;
         }
@@ -905,7 +905,7 @@
                 "paste" !== PasteEventType || msie1x || $el.bind("input.inputmask", inputFallBackEvent), 
                 msie1x && $el.bind("input.inputmask", pasteEvent), (android || androidfirefox || androidchrome || kindle) && ("input" == PasteEventType && $el.unbind(PasteEventType + ".inputmask"), 
                 $el.bind("input.inputmask", mobileInputEvent)), patchValueProperty(el);
-                var initialValue = $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(el, el._valueGet(), opts) || el._valueGet() : el._valueGet();
+                var initialValue = typeof opts.onBeforeMask === "function" ? opts.onBeforeMask.call(el, el._valueGet(), opts) || el._valueGet() : el._valueGet();
                 checkVal(el, !0, !1, initialValue.split(""), !0), valueOnFocus = getBuffer().join("");
                 var activeElement;
                 try {
@@ -936,7 +936,7 @@
                 opts: opts,
                 isRTL: opts.numericInput
             }), opts.numericInput && (isRTL = !0);
-            var valueBuffer = ($.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call($el, actionObj.value, opts) || actionObj.value : actionObj.value).split("");
+            var valueBuffer = (typeof opts.onBeforeMask === "function" ? opts.onBeforeMask.call($el, actionObj.value, opts) || actionObj.value : actionObj.value).split("");
             return checkVal($el, !1, !1, isRTL ? valueBuffer.reverse() : valueBuffer, !0), opts.onKeyPress.call(this, void 0, getBuffer(), 0, opts), 
             actionObj.metadata ? {
                 value: isRTL ? getBuffer().slice().reverse().join("") : getBuffer().join(""),
@@ -1176,7 +1176,7 @@
 
               case "_detectScope":
                 return resolveAlias(opts.alias, options, opts), void 0 == msk || resolveAlias(msk, options, opts) || -1 != $.inArray(msk, [ "mask", "unmaskedvalue", "remove", "getemptymask", "hasMaskedValue", "isComplete", "getmetadata", "_detectScope" ]) || (opts.mask = msk), 
-                $.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray();
+                typeof opts.mask === "function" && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray();
 
               default:
                 return resolveAlias(opts.alias, options, opts), resolveAlias(fn, options, opts) || (opts.mask = fn), 

--- a/fields/phone/masked-input.js
+++ b/fields/phone/masked-input.js
@@ -175,7 +175,7 @@
             }), $.extend(!0, {}, $.inputmask.masksCache[mask]);
         }
         var ms = void 0;
-        if ($.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), $.isArray(opts.mask)) if (multi) ms = [], 
+        if ($.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray()) if (multi) ms = [], 
         $.each(opts.mask, function(ndx, msk) {
             ms.push(void 0 == msk.mask || $.isFunction(msk.mask) ? generateMask(msk.toString(), msk) : generateMask(msk.mask.toString(), msk));
         }); else {
@@ -979,7 +979,7 @@
 
           case "getmetadata":
             if ($el = $(actionObj.el), maskset = $el.data("_inputmask").maskset, opts = $el.data("_inputmask").opts, 
-            $.isArray(maskset.metadata)) {
+            maskset.metadata.isArray()) {
                 for (var alternation, lvp = getLastValidPosition(), firstAlt = lvp; firstAlt >= 0; firstAlt--) if (getMaskSet().validPositions[firstAlt] && void 0 != getMaskSet().validPositions[firstAlt].alternation) {
                     alternation = getMaskSet().validPositions[firstAlt].alternation;
                     break;
@@ -1176,7 +1176,7 @@
 
               case "_detectScope":
                 return resolveAlias(opts.alias, options, opts), void 0 == msk || resolveAlias(msk, options, opts) || -1 != $.inArray(msk, [ "mask", "unmaskedvalue", "remove", "getemptymask", "hasMaskedValue", "isComplete", "getmetadata", "_detectScope" ]) || (opts.mask = msk), 
-                $.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), $.isArray(opts.mask);
+                $.isFunction(opts.mask) && (opts.mask = opts.mask.call(this, opts)), opts.mask.isArray();
 
               default:
                 return resolveAlias(opts.alias, options, opts), resolveAlias(fn, options, opts) || (opts.mask = fn), 

--- a/fields/select2/js/select2.js
+++ b/fields/select2/js/select2.js
@@ -428,7 +428,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (handler && typeof handler.abort === "function") { handler.abort(); }
 
                 if (options.params) {
-                    if ($.isFunction(options.params)) {
+                    if (typeof options.params === "function") {
                         $.extend(params, options.params.call(self));
                     } else {
                         $.extend(params, options.params);
@@ -481,12 +481,12 @@ the specific language governing permissions and limitations under the Apache Lic
             tmp,
             text = function (item) { return ""+item.text; }; // function used to retrieve the text portion of a data item that is matched against the search
 
-         if ($.isArray(data)) {
+         if (data.isArray()) {
             tmp = data;
             data = { results: tmp };
         }
 
-         if ($.isFunction(data) === false) {
+         if (typeof data !== "function") {
             tmp = data;
             data = function() { return tmp; };
         }
@@ -495,7 +495,7 @@ the specific language governing permissions and limitations under the Apache Lic
         if (dataItem.text) {
             text = dataItem.text;
             // if text is not a function we assume it to be a key name
-            if (!$.isFunction(text)) {
+            if (!typeof text === "function") {
                 dataText = dataItem.text; // we need to store this in a separate variable because in the next step data gets reset and data.text is no longer available
                 text = function (item) { return item[dataText]; };
             }
@@ -535,7 +535,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
     // TODO javadoc
     function tags(data) {
-        var isFunc = $.isFunction(data);
+        var isFunc = typeof data === "function";
         return function (query) {
             var t = query.term, filtered = {results: []};
             var result = isFunc ? data(query) : data;
@@ -561,7 +561,7 @@ the specific language governing permissions and limitations under the Apache Lic
      * @param formatter
      */
     function checkFormatter(formatter, formatterName) {
-        if ($.isFunction(formatter)) return true;
+        if (typeof formatter === "function") return true;
         if (!formatter) return false;
         if (typeof(formatter) === 'string') return true;
         throw new Error(formatterName +" must be a string, function, or falsy value");
@@ -576,7 +576,7 @@ the specific language governing permissions and limitations under the Apache Lic
    * @returns {*}
    */
     function evaluate(val, context) {
-        if ($.isFunction(val)) {
+        if (typeof val === "function") {
             var args = Array.prototype.slice.call(arguments, 2);
             return val.apply(context, args);
         }
@@ -818,7 +818,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.nextSearchTerm = undefined;
 
-            if ($.isFunction(this.opts.initSelection)) {
+            if (typeof this.opts.initSelection === "function") {
                 // initialize selection based on the current value of the source element
                 this.initSelection();
 
@@ -1068,7 +1068,7 @@ the specific language governing permissions and limitations under the Apache Lic
                                 $(splitVal(element.val(), opts.separator, opts.transformVal)).each(function () {
                                     var obj = { id: this, text: this },
                                         tags = opts.tags;
-                                    if ($.isFunction(tags)) tags=tags();
+                                    if (typeof tags === "function") tags=tags();
                                     $(tags).each(function() { if (equal(this.id, obj.id)) { obj = this; return false; } });
                                     data.push(obj);
                                 });
@@ -1937,7 +1937,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     }
 
                     return null;
-                } else if ($.isFunction(this.opts.width)) {
+                } else if (typeof this.opts.width === "function") {
                     return this.opts.width();
                 } else {
                     return this.opts.width;
@@ -2358,7 +2358,7 @@ the specific language governing permissions and limitations under the Apache Lic
                             }
                             return is_match;
                         },
-                        callback: !$.isFunction(callback) ? $.noop : function() {
+                        callback: typeof callback !== "function" ? $.noop : function() {
                             callback(match);
                         }
                     });
@@ -2629,7 +2629,7 @@ the specific language governing permissions and limitations under the Apache Lic
                             }
                             return is_match;
                         },
-                        callback: !$.isFunction(callback) ? $.noop : function() {
+                        callback: typeof callback !== "function" ? $.noop : function() {
                             // reorder matches based on the order they appear in the ids array because right now
                             // they are in the order in which they appear in data array
                             var ordered = [];
@@ -3454,7 +3454,7 @@ the specific language governing permissions and limitations under the Apache Lic
         id: function (e) { return e == undefined ? null : e.id; },
         text: function (e) {
           if (e && this.data && this.data.text) {
-            if ($.isFunction(this.data.text)) {
+            if (typeof this.data.text === "function") {
               return this.data.text(e);
             } else {
               return e[this.data.text];


### PR DESCRIPTION
For #3648, jQuery migrate warnings displayed

- [x] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.isArray is deprecated; use Array.isArray

- [x] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.isFunction() is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.delegate() is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.click() event shorthand is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.bind() is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.submit() event shorthand is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.mousedown() event shorthand is deprecated

- [ ] jquery-migrate.js?ver=3.3.2:100 JQMIGRATE: jQuery.fn.focus() event shorthand is deprecated
