### PR TITLE
Extend jQuery 12 script to all CF Pages in admin

### DIFF
--- a/classes/admin/assets.php
+++ b/classes/admin/assets.php
@@ -212,9 +212,10 @@ class Caldera_Forms_Admin_Assets
         if (1 !== strpos($slug, Caldera_Forms::PLUGIN_SLUG)) {
             $slug = self::slug($slug, true);
         }
-        //Fix jQuery issues on main admin page and pinned entry viewer pages
-        if( Caldera_Forms_Admin::is_main_page() || strpos( get_current_screen()->id, "caldera-forms-pin" ) !== false ){
-            wp_enqueue_script( "jqueryOneTwelve",  CFCORE_URL . "/assets/build/js/jquery-12-4.min.js");
+        $curent_page = get_current_screen();
+        //Fix jQuery issues on admin
+        if( is_admin() ){
+           // wp_enqueue_script( "jqueryOneTwelve",  CFCORE_URL . "assets/build/js/jquery-12-4.min.js");
         }
         
         wp_enqueue_script($slug);

--- a/classes/admin/assets.php
+++ b/classes/admin/assets.php
@@ -215,7 +215,7 @@ class Caldera_Forms_Admin_Assets
         $curent_page = get_current_screen();
         //Fix jQuery issues on admin
         if( is_admin() ){
-           // wp_enqueue_script( "jqueryOneTwelve",  CFCORE_URL . "assets/build/js/jquery-12-4.min.js");
+           wp_enqueue_script( "jqueryOneTwelve",  CFCORE_URL . "assets/build/js/jquery-12-4.min.js");
         }
         
         wp_enqueue_script($slug);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "caldera-forms",
-	"version": "1.9.3",
+	"version": "1.9.4-b1",
 	"description": "Apex WordPress Forms",
 	"main": "Gruntfile.js",
 	"repository": {


### PR DESCRIPTION
For #3662 

This help restore the "Save Form" button on the Form edition page when a Stripe processor is in use.