### PR TITLE
Remove precise version of  "symfony/polyfill-mbstring" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "forms",
         "caldera"
     ],
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Josh Pollock",
@@ -34,6 +34,7 @@
         "composer/installers": "^1.6",
         "a5hleyrich/wp-queue": "^1.3",
         "symfony/translation": "~3.0",
+        "symfony/polyfill-mbstring": "1.20",
         "mossadal/math-parser": "^1.3",
         "pimple/pimple": "3.2.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "composer/installers": "^1.6",
         "a5hleyrich/wp-queue": "^1.3",
         "symfony/translation": "~3.0",
-        "symfony/polyfill-mbstring": "1.20",
         "mossadal/math-parser": "^1.3",
         "pimple/pimple": "3.2.*"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "caldera-forms",
-	"version": "1.9.5",
+	"version": "1.9.6-b1",
 	"description": "Apex WordPress Forms",
 	"main": "Gruntfile.js",
 	"repository": {


### PR DESCRIPTION
For #3691 

It seems like the limitation of the  "symfony/polyfill-mbstring" package to version "1.20" is creating this issue. This version was set to prevent an error during the SVN process as the newer version held not compatible files, further testing is required for this PR to be complete.
