### PR TITLE
Improve query performance

### DIFF
--- a/classes/transient.php
+++ b/classes/transient.php
@@ -162,7 +162,7 @@ class Caldera_Forms_Transient  {
 	 */
 	public static function get_all(){
 		global $wpdb;
-		$like = '%' . $wpdb->esc_like( 'cftransdata' ) . '%';
+		$like = $wpdb->esc_like( 'cftransdata' ) . '%';
 		$query = $wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s ", $like );
 		$return = [];
 		$results = $wpdb->get_results($query,ARRAY_A);


### PR DESCRIPTION
This query runs on every request and the first % is not needed thus it's a slow query because the index cannot be used in that case. This makes the query run about 20 times faster on a big table

Applying this patch on my website improved the TTFB by 500ms which is huge